### PR TITLE
Add new paint modes

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -512,7 +512,7 @@ void Canvas::drawBitmap(int X, int Y, Bitmap const * bitmap)
 
 void Canvas::copyToBitmap(int srcX, int srcY, Bitmap const * bitmap)
 {
-  if (bitmap->format != PixelFormat::Native) return;
+  if (bitmap->format != PixelFormat::RGBA2222) return;
   Primitive p;
   p.cmd               = PrimitiveCmd::CopyToBitmap;
   p.bitmapDrawingInfo = BitmapDrawingInfo(srcX, srcY, bitmap);

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -202,13 +202,11 @@ void VGA16Controller::setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect)
 // line clipped on current absolute clipping rectangle
 void VGA16Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 {
-  auto paintMode = paintState().paintOptions.mode;
+  auto paintMode = paintState().paintOptions.NOT ? PaintMode::NOT : paintState().paintOptions.mode;
   genericAbsDrawLine(X1, Y1, X2, Y2, color,
                      getPixelLambda(paintMode),
                      fillRowLambda(paintMode),
-                     [&] (int Y, int X1, int X2) { rawInvertRow(Y, X1, X2); },
-                     setPixelLambda(paintMode),
-                     [&] (int X, int Y)          { VGA16_INVERT_PIXEL(X, Y); }
+                     setPixelLambda(paintMode)
                      );
 }
 

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -546,22 +546,9 @@ void VGA16Controller::readScreen(Rect const & rect, RGB888 * destBuf)
 
 void VGA16Controller::rawDrawBitmap_Native(int destX, int destY, Bitmap const * bitmap, int X1, int Y1, int XCount, int YCount)
 {
-  auto paintMode = paintState().paintOptions.mode;
-  auto setRowPixel = setRowPixelLambda(paintMode);
-
-  if (paintState().paintOptions.swapFGBG) {
-    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
-    auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
-                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
-                              );
-    return;
-  }
-
   genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
                               [&] (int y) { return (uint8_t*) m_viewPort[y]; },   // rawGetRow
-                              setRowPixel
+                              VGA16_SETPIXELINROW
                              );
 }
 
@@ -630,8 +617,11 @@ void VGA16Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const 
 void VGA16Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount)
 {
   genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
-                       [&] (int y)                { return (uint8_t*) m_viewPort[y]; },     // rawGetRow
-                       [&] (uint8_t * row, int x) { return VGA16_GETPIXELINROW(row, x); }   // rawGetPixelInRow
+                         [&] (int y)                { return (uint8_t*) m_viewPort[y]; },     // rawGetRow
+                         [&] (uint8_t * row, int x) {
+                          auto rgb = m_palette[VGA16_GETPIXELINROW(row, x)];
+                          return (0xC0 | (rgb.B << VGA_BLUE_BIT) | (rgb.G << VGA_GREEN_BIT) | (rgb.R << VGA_RED_BIT));
+                         }   // rawGetPixelInRow
                       );
 }
 

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -170,6 +170,34 @@ std::function<void(int X, int Y, uint8_t colorIndex)> VGA16Controller::setPixelL
   }
 }
 
+
+std::function<void(uint8_t * row, int x, uint8_t colorIndex)> VGA16Controller::setRowPixelLambda(PaintMode mode)
+{
+  switch (mode) {
+    case PaintMode::Set:
+      return VGA16_SETPIXELINROW;
+    case PaintMode::OR:
+    case PaintMode::ORNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) | colorIndex);
+      };
+    case PaintMode::AND:
+    case PaintMode::ANDNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) & colorIndex);
+      };
+    case PaintMode::XOR:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) ^ colorIndex);
+      };
+    case PaintMode::Invert:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) { VGA16_INVERTPIXELINROW(row, x); };
+    default:  // PaintMode::NoOp
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) { return; };
+  }
+}
+
+
 std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> VGA16Controller::fillRowLambda(PaintMode mode)
 {
   switch (mode) {
@@ -457,10 +485,13 @@ void VGA16Controller::HScroll(int scroll, Rect & updateRect)
 
 void VGA16Controller::drawGlyph(Glyph const & glyph, GlyphOptions glyphOptions, RGB888 penColor, RGB888 brushColor, Rect & updateRect)
 {
+  auto mode = paintState().paintOptions.mode;
+  auto getPixel = getPixelLambda(mode);
+  auto setRowPixel = setRowPixelLambda(mode);
   genericDrawGlyph(glyph, glyphOptions, penColor, brushColor, updateRect,
-                   [&] (RGB888 const & color)                     { return RGB888toPaletteIndex(color); },
-                   [&] (int y)                                    { return (uint8_t*) m_viewPort[y]; },
-                   VGA16_SETPIXELINROW
+                   getPixel,
+                   [&] (int y) { return (uint8_t*) m_viewPort[y]; },
+                   setRowPixel
                   );
 }
 

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -212,7 +212,7 @@ void VGA16Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 
 
 // parameters not checked
-void VGA16Controller::rawFillRow(int y, int x1, int x2, RGB888 color)
+void VGA16Controller::fillRow(int y, int x1, int x2, RGB888 color)
 {
   // pick fill method based on paint mode
   auto paintMode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -140,13 +140,7 @@ void VGA16Controller::setPaletteItem(int index, RGB888 const & color)
 
 std::function<uint8_t(RGB888 const &)> VGA16Controller::getPixelLambda(PaintMode mode)
 {
-  switch (mode) {
-    case PaintMode::ANDNOT:
-    case PaintMode::ORNOT:
-      return [&] (RGB888 const & color) { return (~RGB888toPaletteIndex(color) & 3); };
-    default: // PaintMode::Set, et al
-      return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
-  }
+  return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
 }
 
 
@@ -156,11 +150,13 @@ std::function<void(int X, int Y, uint8_t colorIndex)> VGA16Controller::setPixelL
     case PaintMode::Set:
       return VGA16_SETPIXEL;
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return VGA16_ORPIXEL;
+    case PaintMode::ORNOT:
+      return [&] (int X, int Y, uint8_t colorIndex) { VGA16_ORPIXEL(X, Y, ~colorIndex & 0x0F); };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return VGA16_ANDPIXEL;
+    case PaintMode::ANDNOT:
+      return [&] (int X, int Y, uint8_t colorIndex) { VGA16_ANDPIXEL(X, Y, ~colorIndex); };
     case PaintMode::XOR:
       return VGA16_XORPIXEL;
     case PaintMode::Invert:
@@ -177,14 +173,20 @@ std::function<void(uint8_t * row, int x, uint8_t colorIndex)> VGA16Controller::s
     case PaintMode::Set:
       return VGA16_SETPIXELINROW;
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
         VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) | colorIndex);
       };
+    case PaintMode::ORNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) | (~colorIndex & 0x0F));
+      };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
         VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) & colorIndex);
+      };
+    case PaintMode::ANDNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA16_SETPIXELINROW(row, x, VGA16_GETPIXELINROW(row, x) & ~colorIndex);
       };
     case PaintMode::XOR:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
@@ -204,11 +206,13 @@ std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> VGA16Controller::
     case PaintMode::Set:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawFillRow(Y, X1, X2, colorIndex); };
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawORRow(Y, X1, X2, colorIndex); };
+    case PaintMode::ORNOT:
+      return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawORRow(Y, X1, X2, ~colorIndex & 0x0F); };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawANDRow(Y, X1, X2, colorIndex); };
+    case PaintMode::ANDNOT:
+      return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawANDRow(Y, X1, X2, ~colorIndex); };
     case PaintMode::XOR:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawXORRow(Y, X1, X2, colorIndex); };
     case PaintMode::Invert:
@@ -542,40 +546,83 @@ void VGA16Controller::readScreen(Rect const & rect, RGB888 * destBuf)
 
 void VGA16Controller::rawDrawBitmap_Native(int destX, int destY, Bitmap const * bitmap, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
+                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                              );
+    return;
+  }
+
   genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
-                              [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                              VGA16_SETPIXELINROW
+                              [&] (int y) { return (uint8_t*) m_viewPort[y]; },   // rawGetRow
+                              setRowPixel
                              );
 }
 
 
 void VGA16Controller::rawDrawBitmap_Mask(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
-  auto foregroundColorIndex = RGB888toPaletteIndex(bitmap->foregroundColor);
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
   genericRawDrawBitmap_Mask(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                            [&] (int y)                  { return (uint8_t*) m_viewPort[y]; },                   // rawGetRow
+                            [&] (int y)                  { return (uint8_t*) m_viewPort[y]; },           // rawGetRow
                             VGA16_GETPIXELINROW,
-                            [&] (uint8_t * row, int x)   { VGA16_SETPIXELINROW(row, x, foregroundColorIndex); }  // rawSetPixelInRow
+                            [&] (uint8_t * row, int x)   { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
                            );
 }
 
 
 void VGA16Controller::rawDrawBitmap_RGBA2222(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_RGBA2222(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
+                                  [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                  VGA16_GETPIXELINROW,                                                           // rawGetPixelInRow
+                                  [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                );
+    return;
+  }
+
   genericRawDrawBitmap_RGBA2222(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },       // rawGetRow
-                                VGA16_GETPIXELINROW,
-                                [&] (uint8_t * row, int x, uint8_t src) { VGA16_SETPIXELINROW(row, x, RGB2222toPaletteIndex(src)); }       // rawSetPixelInRow
+                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },              // rawGetRow
+                                VGA16_GETPIXELINROW,                                                                       // rawGetPixelInRow
+                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
                                );
 }
 
 
 void VGA16Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_RGBA8888(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
+                                  [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                  VGA16_GETPIXELINROW,                                                                    // rawGetPixelInRow
+                                  [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                  );
+    return;
+  }
+
   genericRawDrawBitmap_RGBA8888(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
                                  [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },     // rawGetRow
-                                 [&] (uint8_t * row, int x)                       { return VGA16_GETPIXELINROW(row, x); },  // rawGetPixelInRow
-                                 [&] (uint8_t * row, int x, RGBA8888 const & src) { VGA16_SETPIXELINROW(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
+                                 VGA16_GETPIXELINROW,                                                                       // rawGetPixelInRow
+                                 [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
                                 );
 }
 

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -124,6 +124,7 @@ private:
   // methods to get lambdas to get/set pixels
   std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
   std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(uint8_t * row, int x, uint8_t colorIndex)> setRowPixelLambda(PaintMode mode);
   std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -169,7 +169,8 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawFillRow(int y, int x1, int x2, RGB888 color);
+  void fillRow(int y, int x1, int x2, RGB888 color);
+
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawORRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <atomic>
+#include <functional>
 
 #include "driver/gpio.h"
 
@@ -120,6 +121,10 @@ protected:
 
 private:
 
+  // methods to get lambdas to get/set pixels
+  std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
+  std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController
   void setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect);
@@ -166,6 +171,12 @@ private:
   // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawORRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawANDRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawXORRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawInvertRow(int y, int x1, int x2);
 

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -131,13 +131,6 @@ void VGA2Controller::setPaletteItem(int index, RGB888 const & color)
 std::function<uint8_t(RGB888 const &)> VGA2Controller::getPixelLambda(PaintMode mode)
 {
   return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
-  // switch (mode) {
-  //   case PaintMode::ANDNOT:
-  //   case PaintMode::ORNOT:
-  //     return [&] (RGB888 const & color) { return (~RGB888toPaletteIndex(color) & 1); };
-  //   default: // PaintMode::Set, et al
-  //     return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
-  // }
 }
 
 

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -192,13 +192,11 @@ void VGA2Controller::setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect)
 // line clipped on current absolute clipping rectangle
 void VGA2Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 {
-  auto paintMode = paintState().paintOptions.mode;
+  auto paintMode = paintState().paintOptions.NOT ? PaintMode::NOT : paintState().paintOptions.mode;
   genericAbsDrawLine(X1, Y1, X2, Y2, color,
                      getPixelLambda(paintMode),
                      fillRowLambda(paintMode),
-                     [&] (int Y, int X1, int X2) { rawInvertRow(Y, X1, X2); },
-                     setPixelLambda(paintMode),
-                     [&] (int X, int Y)          { VGA2_INVERT_PIXEL(X, Y); }
+                     setPixelLambda(paintMode)
                      );
 }
 

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -529,22 +529,9 @@ void VGA2Controller::readScreen(Rect const & rect, RGB888 * destBuf)
 
 void VGA2Controller::rawDrawBitmap_Native(int destX, int destY, Bitmap const * bitmap, int X1, int Y1, int XCount, int YCount)
 {
-  auto paintMode = paintState().paintOptions.mode;
-  auto setRowPixel = setRowPixelLambda(paintMode);
-
-  if (paintState().paintOptions.swapFGBG) {
-    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
-    auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
-                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
-                              );
-    return;
-  }
-
   genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
                               [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                              setRowPixel
+                              VGA2_SETPIXELINROW
                              );
 }
 
@@ -614,7 +601,10 @@ void VGA2Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 {
   genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
                        [&] (int y)                { return (uint8_t*) m_viewPort[y]; },   // rawGetRow
-                       [&] (uint8_t * row, int x) { return VGA2_GETPIXELINROW(row, x); }  // rawGetPixelInRow
+                       [&] (uint8_t * row, int x) {
+                         auto rgb = m_palette[VGA2_GETPIXELINROW(row, x)];
+                         return (0xC0 | (rgb.B << VGA_BLUE_BIT) | (rgb.G << VGA_GREEN_BIT) | (rgb.R << VGA_RED_BIT));
+                       }  // rawGetPixelInRow
                       );
 }
 

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -202,7 +202,7 @@ void VGA2Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 
 
 // parameters not checked
-void VGA2Controller::rawFillRow(int y, int x1, int x2, RGB888 color)
+void VGA2Controller::fillRow(int y, int x1, int x2, RGB888 color)
 {
   // pick fill method based on paint mode
   auto paintMode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -171,7 +171,8 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawFillRow(int y, int x1, int x2, RGB888 color);
+  void fillRow(int y, int x1, int x2, RGB888 color);
+
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawORRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -126,6 +126,7 @@ private:
   // methods to get lambdas to get/set pixels
   std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
   std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(uint8_t * row, int x, uint8_t colorIndex)> setRowPixelLambda(PaintMode mode);
   std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <atomic>
+#include <functional>
 
 #include "driver/gpio.h"
 
@@ -122,6 +123,11 @@ protected:
 
 private:
 
+  // methods to get lambdas to get/set pixels
+  std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
+  std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
+
   // abstract method of BitmappedDisplayController
   void setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect);
 
@@ -167,6 +173,12 @@ private:
   // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawORRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawANDRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawXORRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawInvertRow(int y, int x1, int x2);
 

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -220,13 +220,11 @@ void VGA4Controller::setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect)
 // line clipped on current absolute clipping rectangle
 void VGA4Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 {
-  auto paintMode = paintState().paintOptions.mode;
+  auto paintMode = paintState().paintOptions.NOT ? PaintMode::NOT : paintState().paintOptions.mode;
   genericAbsDrawLine(X1, Y1, X2, Y2, color,
                      getPixelLambda(paintMode),
                      fillRowLambda(paintMode),
-                     [&] (int Y, int X1, int X2) { rawInvertRow(Y, X1, X2); },
-                     setPixelLambda(paintMode),
-                     [&] (int X, int Y)          { VGA4_INVERT_PIXEL(X, Y); }
+                     setPixelLambda(paintMode)
                      );
 }
 

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -158,13 +158,7 @@ void VGA4Controller::setPaletteItem(int index, RGB888 const & color)
 
 std::function<uint8_t(RGB888 const &)> VGA4Controller::getPixelLambda(PaintMode mode)
 {
-  switch (mode) {
-    case PaintMode::ANDNOT:
-    case PaintMode::ORNOT:
-      return [&] (RGB888 const & color) { return (~RGB888toPaletteIndex(color) & 3); };
-    default: // PaintMode::Set, et al
-      return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
-  }
+  return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
 }
 
 
@@ -174,11 +168,13 @@ std::function<void(int X, int Y, uint8_t colorIndex)> VGA4Controller::setPixelLa
     case PaintMode::Set:
       return VGA4_SETPIXEL;
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return VGA4_ORPIXEL;
+    case PaintMode::ORNOT:
+      return [&] (int X, int Y, uint8_t colorIndex) { VGA4_ORPIXEL(X, Y, ~colorIndex & 0x03); };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return VGA4_ANDPIXEL;
+    case PaintMode::ANDNOT:
+      return [&] (int X, int Y, uint8_t colorIndex) { VGA4_ANDPIXEL(X, Y, ~colorIndex); };
     case PaintMode::XOR:
       return VGA4_XORPIXEL;
     case PaintMode::Invert:
@@ -195,14 +191,20 @@ std::function<void(uint8_t * row, int x, uint8_t colorIndex)> VGA4Controller::se
     case PaintMode::Set:
       return VGA4_SETPIXELINROW;
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
         VGA4_SETPIXELINROW(row, x, VGA4_GETPIXELINROW(row, x) | colorIndex);
       };
+    case PaintMode::ORNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA4_SETPIXELINROW(row, x, VGA4_GETPIXELINROW(row, x) | (~colorIndex & 0x03));
+      };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
         VGA4_SETPIXELINROW(row, x, VGA4_GETPIXELINROW(row, x) & colorIndex);
+      };
+    case PaintMode::ANDNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA4_SETPIXELINROW(row, x, VGA4_GETPIXELINROW(row, x) & ~colorIndex);
       };
     case PaintMode::XOR:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
@@ -222,11 +224,13 @@ std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> VGA4Controller::f
     case PaintMode::Set:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawFillRow(Y, X1, X2, colorIndex); };
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawORRow(Y, X1, X2, colorIndex); };
+    case PaintMode::ORNOT:
+      return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawORRow(Y, X1, X2, ~colorIndex & 0x03); };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawANDRow(Y, X1, X2, colorIndex); };
+    case PaintMode::ANDNOT:
+      return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawANDRow(Y, X1, X2, ~colorIndex); };
     case PaintMode::XOR:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawXORRow(Y, X1, X2, colorIndex); };
     case PaintMode::Invert:
@@ -555,40 +559,82 @@ void VGA4Controller::readScreen(Rect const & rect, RGB888 * destBuf)
 
 void VGA4Controller::rawDrawBitmap_Native(int destX, int destY, Bitmap const * bitmap, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
+                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                              );
+    return;
+  }
+
   genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
-                              [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                              VGA4_SETPIXELINROW
+                              [&] (int y) { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                              setRowPixel
                              );
 }
 
 
 void VGA4Controller::rawDrawBitmap_Mask(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
-  auto foregroundColorIndex = RGB888toPaletteIndex(bitmap->foregroundColor);
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
   genericRawDrawBitmap_Mask(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                            [&] (int y)                  { return (uint8_t*) m_viewPort[y]; },                  // rawGetRow
+                            [&] (int y)                  { return (uint8_t*) m_viewPort[y]; },           // rawGetRow
                             VGA4_GETPIXELINROW,
-                            [&] (uint8_t * row, int x)   { VGA4_SETPIXELINROW(row, x, foregroundColorIndex); }  // rawSetPixelInRow
+                            [&] (uint8_t * row, int x)   { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
                            );
 }
 
 
 void VGA4Controller::rawDrawBitmap_RGBA2222(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_RGBA2222(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
+                                  [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                  VGA4_GETPIXELINROW,                                                            // rawGetPixelInRow
+                                  [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                );
+    return;
+  }
+
   genericRawDrawBitmap_RGBA2222(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },                             // rawGetRow
+                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },                 // rawGetRow
                                 VGA4_GETPIXELINROW,
-                                [&] (uint8_t * row, int x, uint8_t src) { VGA4_SETPIXELINROW(row, x, RGB2222toPaletteIndex(src)); }       // rawSetPixelInRow
+                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
                                );
 }
 
 
 void VGA4Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_RGBA8888(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
+                                  [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                  VGA4_GETPIXELINROW,                                                                     // rawGetPixelInRow
+                                  [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                  );
+    return;
+  }
   genericRawDrawBitmap_RGBA8888(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                                 [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },                         // rawGetRow
-                                 [&] (uint8_t * row, int x)                       { return VGA4_GETPIXELINROW(row, x); },                       // rawGetPixelInRow
-                                 [&] (uint8_t * row, int x, RGBA8888 const & src) { VGA4_SETPIXELINROW(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
+                                 [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },                  // rawGetRow
+                                 VGA4_GETPIXELINROW,                                                                                     // rawGetPixelInRow
+                                 [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
                                 );
 }
 

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -230,7 +230,7 @@ void VGA4Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 
 
 // parameters not checked
-void VGA4Controller::rawFillRow(int y, int x1, int x2, RGB888 color)
+void VGA4Controller::fillRow(int y, int x1, int x2, RGB888 color)
 {
   // pick fill method based on paint mode
   auto paintMode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -168,7 +168,8 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawFillRow(int y, int x1, int x2, RGB888 color);
+  void fillRow(int y, int x1, int x2, RGB888 color);
+
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawORRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -123,6 +123,7 @@ private:
   // methods to get lambdas to get/set pixels
   std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
   std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(uint8_t * row, int x, uint8_t colorIndex)> setRowPixelLambda(PaintMode mode);
   std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <atomic>
+#include <functional>
 
 #include "driver/gpio.h"
 
@@ -119,6 +120,11 @@ protected:
 
 private:
 
+  // methods to get lambdas to get/set pixels
+  std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
+  std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
+
   // abstract method of BitmappedDisplayController
   void setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect);
 
@@ -164,6 +170,12 @@ private:
   // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawORRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawANDRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawXORRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawInvertRow(int y, int x1, int x2);
 

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -238,7 +238,7 @@ void VGA8Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 
 
 // parameters not checked
-void VGA8Controller::rawFillRow(int y, int x1, int x2, RGB888 color)
+void VGA8Controller::fillRow(int y, int x1, int x2, RGB888 color)
 {
   // pick fill method based on paint mode
   auto paintMode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -228,13 +228,11 @@ void VGA8Controller::setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect)
 // line clipped on current absolute clipping rectangle
 void VGA8Controller::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 {
-  auto paintMode = paintState().paintOptions.mode;
+  auto paintMode = paintState().paintOptions.NOT ? PaintMode::NOT : paintState().paintOptions.mode;
   genericAbsDrawLine(X1, Y1, X2, Y2, color,
                      getPixelLambda(paintMode),
                      fillRowLambda(paintMode),
-                     [&] (int Y, int X1, int X2) { rawInvertRow(Y, X1, X2); },
-                     setPixelLambda(paintMode),
-                     [&] (int X, int Y)          { VGA8_INVERT_PIXEL(X, Y); }
+                     setPixelLambda(paintMode)
                      );
 }
 

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -166,13 +166,7 @@ void VGA8Controller::setPaletteItem(int index, RGB888 const & color)
 
 std::function<uint8_t(RGB888 const &)> VGA8Controller::getPixelLambda(PaintMode mode)
 {
-  switch (mode) {
-    case PaintMode::ANDNOT:
-    case PaintMode::ORNOT:
-      return [&] (RGB888 const & color) { return (~RGB888toPaletteIndex(color) & 7); };
-    default: // PaintMode::Set, et al
-      return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
-  }
+  return [&] (RGB888 const & color) { return RGB888toPaletteIndex(color); };
 }
 
 
@@ -182,11 +176,13 @@ std::function<void(int X, int Y, uint8_t colorIndex)> VGA8Controller::setPixelLa
     case PaintMode::Set:
       return VGA8_SETPIXEL;
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return VGA8_ORPIXEL;
+    case PaintMode::ORNOT:
+      return [&] (int X, int Y, uint8_t colorIndex) { VGA8_ORPIXEL(X, Y, ~colorIndex & 0x07); };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return VGA8_ANDPIXEL;
+    case PaintMode::ANDNOT:
+      return [&] (int X, int Y, uint8_t colorIndex) { VGA8_ANDPIXEL(X, Y, ~colorIndex); };
     case PaintMode::XOR:
       return VGA8_XORPIXEL;
     case PaintMode::Invert:
@@ -203,14 +199,20 @@ std::function<void(uint8_t * row, int x, uint8_t colorIndex)> VGA8Controller::se
     case PaintMode::Set:
       return VGA8_SETPIXELINROW;
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
         VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) | colorIndex);
       };
+    case PaintMode::ORNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) | (~colorIndex & 0x07));
+      };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
         VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) & colorIndex);
+      };
+    case PaintMode::ANDNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) & ~colorIndex);
       };
     case PaintMode::XOR:
       return [&] (uint8_t * row, int x, uint8_t colorIndex) {
@@ -230,11 +232,13 @@ std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> VGA8Controller::f
     case PaintMode::Set:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawFillRow(Y, X1, X2, colorIndex); };
     case PaintMode::OR:
-    case PaintMode::ORNOT:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawORRow(Y, X1, X2, colorIndex); };
+    case PaintMode::ORNOT:
+      return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawORRow(Y, X1, X2, ~colorIndex & 0x07); };
     case PaintMode::AND:
-    case PaintMode::ANDNOT:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawANDRow(Y, X1, X2, colorIndex); };
+    case PaintMode::ANDNOT:
+      return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawANDRow(Y, X1, X2, ~colorIndex); };
     case PaintMode::XOR:
       return [&] (int Y, int X1, int X2, uint8_t colorIndex) { rawXORRow(Y, X1, X2, colorIndex); };
     case PaintMode::Invert:
@@ -502,40 +506,83 @@ void VGA8Controller::readScreen(Rect const & rect, RGB888 * destBuf)
 
 void VGA8Controller::rawDrawBitmap_Native(int destX, int destY, Bitmap const * bitmap, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
+                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                              );
+    return;
+  }
+
   genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
-                              [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                              VGA8_SETPIXELINROW
+                              [&] (int y) { return (uint8_t*) m_viewPort[y]; },   // rawGetRow
+                              setRowPixel
                              );
 }
 
 
 void VGA8Controller::rawDrawBitmap_Mask(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
-  auto foregroundColorIndex = RGB888toPaletteIndex(bitmap->foregroundColor);
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
   genericRawDrawBitmap_Mask(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                            [&] (int y)                  { return (uint8_t*) m_viewPort[y]; },                  // rawGetRow
+                            [&] (int y)                  { return (uint8_t*) m_viewPort[y]; },          // rawGetRow
                             VGA8_GETPIXELINROW,
-                            [&] (uint8_t * row, int x)   { VGA8_SETPIXELINROW(row, x, foregroundColorIndex); }  // rawSetPixelInRow
+                            [&] (uint8_t * row, int x)   { setRowPixel(row, x, foregroundColorIndex); } // rawSetPixelInRow
                            );
 }
 
 
 void VGA8Controller::rawDrawBitmap_RGBA2222(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_RGBA2222(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
+                                  [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                  VGA8_GETPIXELINROW,                                                            // rawGetPixelInRow
+                                  [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                );
+    return;
+  }
+
   genericRawDrawBitmap_RGBA2222(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },                             // rawGetRow
+                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },                 // rawGetRow
                                 VGA8_GETPIXELINROW,
-                                [&] (uint8_t * row, int x, uint8_t src) { VGA8_SETPIXELINROW(row, x, RGB2222toPaletteIndex(src)); }       // rawSetPixelInRow
+                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
                                );
 }
 
 
 void VGA8Controller::rawDrawBitmap_RGBA8888(int destX, int destY, Bitmap const * bitmap, void * saveBackground, int X1, int Y1, int XCount, int YCount)
 {
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawBitmap_RGBA8888(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
+                                  [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                  VGA8_GETPIXELINROW,                                                                     // rawGetPixelInRow
+                                  [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                  );
+    return;
+  }
+
   genericRawDrawBitmap_RGBA8888(destX, destY, bitmap, (uint8_t*)saveBackground, X1, Y1, XCount, YCount,
-                                 [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },                         // rawGetRow
-                                 [&] (uint8_t * row, int x)                       { return VGA8_GETPIXELINROW(row, x); },                       // rawGetPixelInRow
-                                 [&] (uint8_t * row, int x, RGBA8888 const & src) { VGA8_SETPIXELINROW(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
+                                 [&] (int y)                                      { return (uint8_t*) m_viewPort[y]; },                 // rawGetRow
+                                 VGA8_GETPIXELINROW,                                                                                    // rawGetPixelInRow
+                                 [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }  // rawSetPixelInRow
                                 );
 }
 

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -506,22 +506,9 @@ void VGA8Controller::readScreen(Rect const & rect, RGB888 * destBuf)
 
 void VGA8Controller::rawDrawBitmap_Native(int destX, int destY, Bitmap const * bitmap, int X1, int Y1, int XCount, int YCount)
 {
-  auto paintMode = paintState().paintOptions.mode;
-  auto setRowPixel = setRowPixelLambda(paintMode);
-
-  if (paintState().paintOptions.swapFGBG) {
-    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
-    auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
-                                [&] (int y)                             { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                                [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
-                              );
-    return;
-  }
-
   genericRawDrawBitmap_Native(destX, destY, (uint8_t*) bitmap->data, bitmap->width, X1, Y1, XCount, YCount,
                               [&] (int y) { return (uint8_t*) m_viewPort[y]; },   // rawGetRow
-                              setRowPixel
+                              VGA8_SETPIXELINROW
                              );
 }
 
@@ -591,7 +578,10 @@ void VGA8Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 {
   genericRawCopyToBitmap(srcX, srcY, width, (uint8_t*)saveBuffer, X1, Y1, XCount, YCount,
                         [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
-                        [&] (uint8_t * row, int x) { return VGA8_GETPIXELINROW(row, x); } // rawGetPixelInRow
+                        [&] (uint8_t * row, int x) {
+                          auto rgb = m_palette[VGA8_GETPIXELINROW(row, x)];
+                          return (0xC0 | (rgb.B << VGA_BLUE_BIT) | (rgb.G << VGA_GREEN_BIT) | (rgb.R << VGA_RED_BIT));
+                        } // rawGetPixelInRow
                       );
 }
 

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -196,6 +196,34 @@ std::function<void(int X, int Y, uint8_t colorIndex)> VGA8Controller::setPixelLa
   }
 }
 
+
+std::function<void(uint8_t * row, int x, uint8_t colorIndex)> VGA8Controller::setRowPixelLambda(PaintMode mode)
+{
+  switch (mode) {
+    case PaintMode::Set:
+      return VGA8_SETPIXELINROW;
+    case PaintMode::OR:
+    case PaintMode::ORNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) | colorIndex);
+      };
+    case PaintMode::AND:
+    case PaintMode::ANDNOT:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) & colorIndex);
+      };
+    case PaintMode::XOR:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) {
+        VGA8_SETPIXELINROW(row, x, VGA8_GETPIXELINROW(row, x) ^ colorIndex);
+      };
+    case PaintMode::Invert:
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) { VGA8_INVERTPIXELINROW(row, x); };
+    default:  // PaintMode::NoOp
+      return [&] (uint8_t * row, int x, uint8_t colorIndex) { return; };
+  }
+}
+
+
 std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> VGA8Controller::fillRowLambda(PaintMode mode)
 {
   switch (mode) {
@@ -417,10 +445,13 @@ void VGA8Controller::HScroll(int scroll, Rect & updateRect)
 
 void VGA8Controller::drawGlyph(Glyph const & glyph, GlyphOptions glyphOptions, RGB888 penColor, RGB888 brushColor, Rect & updateRect)
 {
+  auto mode = paintState().paintOptions.mode;
+  auto getPixel = getPixelLambda(mode);
+  auto setRowPixel = setRowPixelLambda(mode);
   genericDrawGlyph(glyph, glyphOptions, penColor, brushColor, updateRect,
-                   [&] (RGB888 const & color)                     { return RGB888toPaletteIndex(color); },
-                   [&] (int y)                                    { return (uint8_t*) m_viewPort[y]; },
-                   VGA8_SETPIXELINROW
+                   getPixel,
+                   [&] (int y) { return (uint8_t*) m_viewPort[y]; },
+                   setRowPixel
                   );
 }
 

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <atomic>
+#include <functional>
 
 #include "driver/gpio.h"
 
@@ -123,6 +124,11 @@ protected:
 
 private:
 
+  // methods to get lambdas to get/set pixels
+  std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
+  std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
+
   // abstract method of BitmappedDisplayController
   void setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect);
 
@@ -168,6 +174,12 @@ private:
   // abstract method of BitmappedDisplayController
   void rawFillRow(int y, int x1, int x2, RGB888 color);
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawORRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawANDRow(int y, int x1, int x2, uint8_t colorIndex);
+
+  void rawXORRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawInvertRow(int y, int x1, int x2);
 

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -127,6 +127,7 @@ private:
   // methods to get lambdas to get/set pixels
   std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
   std::function<void(int X, int Y, uint8_t colorIndex)> setPixelLambda(PaintMode mode);
+  std::function<void(uint8_t * row, int x, uint8_t colorIndex)> setRowPixelLambda(PaintMode mode);
   std::function<void(int Y, int X1, int X2, uint8_t colorIndex)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -172,7 +172,8 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawFillRow(int y, int x1, int x2, RGB888 color);
+  void fillRow(int y, int x1, int x2, RGB888 color);
+
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);
 
   void rawORRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -220,14 +220,11 @@ void IRAM_ATTR VGAController::setPixelAt(PixelDesc const & pixelDesc, Rect & upd
 // line clipped on current absolute clipping rectangle
 void IRAM_ATTR VGAController::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color)
 {
-  auto paintMode = paintState().paintOptions.mode;
-
+  auto paintMode = paintState().paintOptions.NOT ? PaintMode::NOT : paintState().paintOptions.mode;
   genericAbsDrawLine(X1, Y1, X2, Y2, color,
                      getPixelLambda(paintMode),
                      fillRowLambda(paintMode),
-                     [&] (int Y, int X1, int X2) { rawInvertRow(Y, X1, X2); },
-                     setPixelLambda(paintMode),
-                     [&] (int X, int Y)          { VGA_INVERT_PIXEL(X, Y); }
+                     setPixelLambda(paintMode)
                      );
 }
 

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -222,7 +222,13 @@ void IRAM_ATTR VGAController::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888
 // parameters not checked
 void IRAM_ATTR VGAController::rawFillRow(int y, int x1, int x2, RGB888 color)
 {
-  rawFillRow(y, x1, x2, preparePixel(color));
+  // This version, passing an RGB888 color, is only used by shape drawing methods,
+  // so we will pick fill method based on paint mode
+  auto paintMode = paintState().paintOptions.mode;
+  auto getPixel = getPixelLamda(paintMode);
+  auto pixel = getPixel(color);
+  auto fill = fillRowLamda(paintMode);
+  fill(y, x1, x2, pixel);
 }
 
 
@@ -315,10 +321,8 @@ void IRAM_ATTR VGAController::swapRows(int yA, int yB, int x1, int x2)
 
 void IRAM_ATTR VGAController::drawEllipse(Size const & size, Rect & updateRect)
 {
-  genericDrawEllipse(size, updateRect,
-                     [&] (RGB888 const & color)          { return preparePixel(color); },
-                     [&] (int X, int Y, uint8_t pattern) { VGA_PIXEL(X, Y) = pattern; }
-                    );
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipse(size, updateRect, getPixelLamda(mode), setPixelLamda(mode));
 }
 
 

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -230,7 +230,7 @@ void IRAM_ATTR VGAController::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888
 
 
 // parameters not checked
-void IRAM_ATTR VGAController::rawFillRow(int y, int x1, int x2, RGB888 color)
+void IRAM_ATTR VGAController::fillRow(int y, int x1, int x2, RGB888 color)
 {
   // This version, passing an RGB888 color, is only used by shape drawing methods,
   // so we will pick fill method based on paint mode

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -158,7 +158,7 @@ std::function<uint8_t(RGB888 const &)> VGAController::getPixelLambda(PaintMode m
       return [&] (RGB888 const & color) { return preparePixel(color) & 63; };
     case PaintMode::ANDNOT:
     case PaintMode::ORNOT:
-      return [&] (RGB888 const & color) { return (~preparePixel(color) & 63) || m_HVSync; };
+      return [&] (RGB888 const & color) { return (~preparePixel(color) & 63) | m_HVSync; };
     default: // PaintMode::Set, et al
       return [&] (RGB888 const & color) { return preparePixel(color); };
   }

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -352,9 +352,9 @@ void IRAM_ATTR VGAController::clear(Rect & updateRect)
 void IRAM_ATTR VGAController::VScroll(int scroll, Rect & updateRect)
 {
   genericVScroll(scroll, updateRect,
-                 [&] (int yA, int yB, int x1, int x2)        { swapRows(yA, yB, x1, x2); },              // swapRowsCopying
-                 [&] (int yA, int yB)                        { tswap(m_viewPort[yA], m_viewPort[yB]); }, // swapRowsPointers
-                 [&] (int y, int x1, int x2, RGB888 pattern) { rawFillRow(y, x1, x2, pattern); }         // rawFillRow
+                 [&] (int yA, int yB, int x1, int x2)      { swapRows(yA, yB, x1, x2); },              // swapRowsCopying
+                 [&] (int yA, int yB)                      { tswap(m_viewPort[yA], m_viewPort[yB]); }, // swapRowsPointers
+                 [&] (int y, int x1, int x2, RGB888 color) { rawFillRow(y, x1, x2, preparePixel(color)); }         // rawFillRow
                 );
 
   if (scroll != 0) {

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -164,6 +164,7 @@ std::function<uint8_t(RGB888 const &)> VGAController::getPixelLambda(PaintMode m
   }
 }
 
+
 std::function<void(int X, int Y, uint8_t pattern)> VGAController::setPixelLambda(PaintMode mode)
 {
   switch (mode) {
@@ -183,6 +184,7 @@ std::function<void(int X, int Y, uint8_t pattern)> VGAController::setPixelLambda
       return [&] (int X, int Y, uint8_t pattern) { return; };
   }
 }
+
 
 std::function<void(int Y, int X1, int X2, uint8_t pattern)> VGAController::fillRowLambda(PaintMode mode)
 {

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -151,7 +151,7 @@ void IRAM_ATTR VGAController::VSyncInterrupt(void * arg)
 }
 
 
-std::function<uint8_t(RGB888 const &)> VGAController::getPixelLamda(PaintMode mode)
+std::function<uint8_t(RGB888 const &)> VGAController::getPixelLambda(PaintMode mode)
 {
   switch (mode) {
     case PaintMode::XOR:
@@ -164,7 +164,7 @@ std::function<uint8_t(RGB888 const &)> VGAController::getPixelLamda(PaintMode mo
   }
 }
 
-std::function<void(int X, int Y, uint8_t pattern)> VGAController::setPixelLamda(PaintMode mode)
+std::function<void(int X, int Y, uint8_t pattern)> VGAController::setPixelLambda(PaintMode mode)
 {
   switch (mode) {
     case PaintMode::Set:
@@ -184,7 +184,7 @@ std::function<void(int X, int Y, uint8_t pattern)> VGAController::setPixelLamda(
   }
 }
 
-std::function<void(int Y, int X1, int X2, uint8_t pattern)> VGAController::fillRowLamda(PaintMode mode)
+std::function<void(int Y, int X1, int X2, uint8_t pattern)> VGAController::fillRowLambda(PaintMode mode)
 {
   switch (mode) {
     case PaintMode::Set:
@@ -209,7 +209,7 @@ std::function<void(int Y, int X1, int X2, uint8_t pattern)> VGAController::fillR
 void IRAM_ATTR VGAController::setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect)
 {
   auto paintMode = paintState().paintOptions.mode;
-  genericSetPixelAt(pixelDesc, updateRect, getPixelLamda(paintMode), setPixelLamda(paintMode));
+  genericSetPixelAt(pixelDesc, updateRect, getPixelLambda(paintMode), setPixelLambda(paintMode));
 }
 
 
@@ -221,10 +221,10 @@ void IRAM_ATTR VGAController::absDrawLine(int X1, int Y1, int X2, int Y2, RGB888
   auto paintMode = paintState().paintOptions.mode;
 
   genericAbsDrawLine(X1, Y1, X2, Y2, color,
-                     getPixelLamda(paintMode),
-                     fillRowLamda(paintMode),
+                     getPixelLambda(paintMode),
+                     fillRowLambda(paintMode),
                      [&] (int Y, int X1, int X2) { rawInvertRow(Y, X1, X2); },
-                     setPixelLamda(paintMode),
+                     setPixelLambda(paintMode),
                      [&] (int X, int Y)          { VGA_INVERT_PIXEL(X, Y); }
                      );
 }
@@ -236,9 +236,9 @@ void IRAM_ATTR VGAController::rawFillRow(int y, int x1, int x2, RGB888 color)
   // This version, passing an RGB888 color, is only used by shape drawing methods,
   // so we will pick fill method based on paint mode
   auto paintMode = paintState().paintOptions.mode;
-  auto getPixel = getPixelLamda(paintMode);
+  auto getPixel = getPixelLambda(paintMode);
   auto pixel = getPixel(color);
-  auto fill = fillRowLamda(paintMode);
+  auto fill = fillRowLambda(paintMode);
   fill(y, x1, x2, pixel);
 }
 
@@ -333,7 +333,7 @@ void IRAM_ATTR VGAController::swapRows(int yA, int yB, int x1, int x2)
 void IRAM_ATTR VGAController::drawEllipse(Size const & size, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;
-  genericDrawEllipse(size, updateRect, getPixelLamda(mode), setPixelLamda(mode));
+  genericDrawEllipse(size, updateRect, getPixelLambda(mode), setPixelLambda(mode));
 }
 
 

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -201,9 +201,10 @@ private:
   void allocateViewPort();
   void onSetupDMABuffer(lldesc_t volatile * buffer, bool isStartOfVertFrontPorch, int scan, bool isVisible, int visibleRow);
 
-  std::function<uint8_t(RGB888 const &)> getPixelLamda(PaintMode mode);
-  std::function<void(int X, int Y, uint8_t pattern)> setPixelLamda(PaintMode mode);
-  std::function<void(int Y, int X1, int X2, uint8_t pattern)> fillRowLamda(PaintMode mode);
+  // methods to get lambdas to get/set pixels
+  std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
+  std::function<void(int X, int Y, uint8_t pattern)> setPixelLambda(PaintMode mode);
+  std::function<void(int Y, int X1, int X2, uint8_t pattern)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController
   void setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect);

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -204,6 +204,7 @@ private:
   // methods to get lambdas to get/set pixels
   std::function<uint8_t(RGB888 const &)> getPixelLambda(PaintMode mode);
   std::function<void(int X, int Y, uint8_t pattern)> setPixelLambda(PaintMode mode);
+  std::function<void(uint8_t * row, int x, uint8_t pattern)> setRowPixelLambda(PaintMode mode);
   std::function<void(int Y, int X1, int X2, uint8_t pattern)> fillRowLambda(PaintMode mode);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -249,7 +249,7 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawFillRow(int y, int x1, int x2, RGB888 color);
+  void fillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t pattern);
 

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -38,6 +38,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <atomic>
+#include <functional>
 
 #include "driver/gpio.h"
 
@@ -200,6 +201,10 @@ private:
   void allocateViewPort();
   void onSetupDMABuffer(lldesc_t volatile * buffer, bool isStartOfVertFrontPorch, int scan, bool isVisible, int visibleRow);
 
+  std::function<uint8_t(RGB888 const &)> getPixelLamda(PaintMode mode);
+  std::function<void(int X, int Y, uint8_t pattern)> setPixelLamda(PaintMode mode);
+  std::function<void(int Y, int X1, int X2, uint8_t pattern)> fillRowLamda(PaintMode mode);
+
   // abstract method of BitmappedDisplayController
   void setPixelAt(PixelDesc const & pixelDesc, Rect & updateRect);
 
@@ -246,6 +251,12 @@ private:
   void rawFillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t pattern);
+
+  void rawORRow(int y, int x1, int x2, uint8_t pattern);
+
+  void rawANDRow(int y, int x1, int x2, uint8_t pattern);
+
+  void rawXORRow(int y, int x1, int x2, uint8_t pattern);
 
   void rawInvertRow(int y, int x1, int x2);
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -535,6 +535,8 @@ void BitmappedDisplayController::setSprites(Sprite * sprites, int count, int spr
 {
   processPrimitives();
   primitivesExecutionWait();
+  auto updateRect = Rect(0, 0, getViewPortWidth() - 1, getViewPortHeight() - 1);
+  hideSprites(updateRect);
   m_sprites      = sprites;
   m_spriteSize   = spriteSize;
   m_spritesCount = count;
@@ -544,7 +546,6 @@ void BitmappedDisplayController::setSprites(Sprite * sprites, int count, int spr
     uint8_t * spritePtr = (uint8_t*)m_sprites;
     for (int i = 0; i < m_spritesCount; ++i, spritePtr += m_spriteSize) {
       Sprite * sprite = (Sprite*) spritePtr;
-      sprite->savedBackgroundWidth = 0;
       int reqBackBufferSize = 0;
       for (int i = 0; i < sprite->framesCount; ++i)
         reqBackBufferSize = tmax(reqBackBufferSize, sprite->frames[i]->width * getBitmapSavePixelSize() * sprite->frames[i]->height);
@@ -552,6 +553,7 @@ void BitmappedDisplayController::setSprites(Sprite * sprites, int count, int spr
         sprite->savedBackground = (uint8_t*) realloc(sprite->savedBackground, reqBackBufferSize);
     }
   }
+  showSprites(updateRect);
 }
 
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -167,6 +167,7 @@ Sprite::Sprite()
   visible                 = true;
   isStatic                = false;
   allowDraw               = true;
+  paintOptions            = PaintOptions();
 }
 
 
@@ -570,6 +571,9 @@ void IRAM_ATTR BitmappedDisplayController::hideSprites(Rect & updateRect)
 {
   if (!m_spritesHidden) {
     m_spritesHidden = true;
+    auto & options = paintState().paintOptions;
+    auto savedPaintMode = options.mode;
+    options.mode = PaintMode::Set;
 
     // normal sprites
     if (spritesCount() > 0 && !isDoubleBuffered()) {
@@ -602,6 +606,7 @@ void IRAM_ATTR BitmappedDisplayController::hideSprites(Rect & updateRect)
       mouseSprite->savedBackgroundWidth = mouseSprite->savedBackgroundHeight = 0;
     }
 
+    options.mode = savedPaintMode;
   }
 }
 
@@ -610,6 +615,7 @@ void IRAM_ATTR BitmappedDisplayController::showSprites(Rect & updateRect)
 {
   if (m_spritesHidden) {
     m_spritesHidden = false;
+    auto options = paintState().paintOptions;
 
     // normal sprites
     // save backgrounds and draw sprites
@@ -622,6 +628,7 @@ void IRAM_ATTR BitmappedDisplayController::showSprites(Rect & updateRect)
         Bitmap const * bitmap = sprite->getFrame();
         int bitmapWidth  = bitmap->width;
         int bitmapHeight = bitmap->height;
+        paintState().paintOptions = sprite->paintOptions;
         absDrawBitmap(spriteX, spriteY, bitmap, sprite->savedBackground, true);
         sprite->savedX = spriteX;
         sprite->savedY = spriteY;
@@ -643,6 +650,7 @@ void IRAM_ATTR BitmappedDisplayController::showSprites(Rect & updateRect)
       Bitmap const * bitmap = mouseSprite->getFrame();
       int bitmapWidth  = bitmap->width;
       int bitmapHeight = bitmap->height;
+      paintState().paintOptions = PaintOptions();
       absDrawBitmap(spriteX, spriteY, bitmap, mouseSprite->savedBackground, true);
       mouseSprite->savedX = spriteX;
       mouseSprite->savedY = spriteY;
@@ -651,6 +659,7 @@ void IRAM_ATTR BitmappedDisplayController::showSprites(Rect & updateRect)
       updateRect = updateRect.merge(Rect(spriteX, spriteY, spriteX + bitmapWidth - 1, spriteY + bitmapHeight - 1));
     }
 
+    paintState().paintOptions = options;
   }
 }
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -544,6 +544,7 @@ void BitmappedDisplayController::setSprites(Sprite * sprites, int count, int spr
     uint8_t * spritePtr = (uint8_t*)m_sprites;
     for (int i = 0; i < m_spritesCount; ++i, spritePtr += m_spriteSize) {
       Sprite * sprite = (Sprite*) spritePtr;
+      sprite->savedBackgroundWidth = 0;
       int reqBackBufferSize = 0;
       for (int i = 0; i < sprite->framesCount; ++i)
         reqBackBufferSize = tmax(reqBackBufferSize, sprite->frames[i]->width * getBitmapSavePixelSize() * sprite->frames[i]->height);

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -899,7 +899,7 @@ void IRAM_ATTR BitmappedDisplayController::fillRect(Rect const & rect, RGB888 co
   hideSprites(updateRect);
 
   for (int y = y1; y <= y2; ++y)
-    rawFillRow(y, x1, x2, color);
+    fillRow(y, x1, x2, color);
 }
 
 
@@ -946,9 +946,9 @@ void IRAM_ATTR BitmappedDisplayController::fillEllipse(int centerX, int centerY,
         int row1 = centerY - y;
         int row2 = centerY + y;
         if (row1 >= clipY1 && row1 <= clipY2)
-          rawFillRow(row1, col1, col2, color);
+          fillRow(row1, col1, col2, color);
         if (y != 0 && row2 >= clipY1 && row2 <= clipY2)
-          rawFillRow(row2, col1, col2, color);
+          fillRow(row2, col1, col2, color);
       }
       if (t - a2 * y <= crit2) {
         x++;
@@ -963,7 +963,7 @@ void IRAM_ATTR BitmappedDisplayController::fillEllipse(int centerX, int centerY,
   }
   // one line horizontal ellipse case
   if (halfHeight == 0 && centerY >= clipY1 && centerY <= clipY2)
-    rawFillRow(centerY, iclamp(centerX - halfWidth, clipX1, clipX2), iclamp(centerX - halfWidth + 2 * halfWidth + 1, clipX1, clipX2), color);
+    fillRow(centerY, iclamp(centerX - halfWidth, clipX1, clipX2), iclamp(centerX - halfWidth + 2 * halfWidth + 1, clipX1, clipX2), color);
 }
 
 
@@ -1105,7 +1105,7 @@ void IRAM_ATTR BitmappedDisplayController::fillPath(Path const & path, RGB888 co
           nodeX[i] = minX;
         if (nodeX[i + 1] > maxX)
           nodeX[i + 1] = maxX;
-        rawFillRow(pixelY, nodeX[i], nodeX[i + 1] - 1, color);
+        fillRow(pixelY, nodeX[i], nodeX[i + 1] - 1, color);
       }
     }
   }

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -599,6 +599,9 @@ enum PaintMode : uint8_t {
   XOR = 3,      // XOR colour onto screen
   Invert = 4,   // Invert colour on screen
   NOT = 4,      // NOT colour onto screen, alias for Invert
+  NoOp = 5,     // No operation
+  ANDNOT = 6,   // AND colour on screen with NOT colour
+  ORNOT = 7,    // OR colour on screen with NOT colour
 };
 
 /**

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -1087,8 +1087,8 @@ protected:
 
   // coordinates are absolute values (not relative to origin)
   // line clipped on current absolute clipping rectangle
-  template <typename TPreparePixel, typename TRawFillRow, typename TRawInvertRow, typename TRawSetPixel, typename TRawInvertPixel>
-  void genericAbsDrawLine(int X1, int Y1, int X2, int Y2, RGB888 const & color, TPreparePixel preparePixel, TRawFillRow rawFillRow, TRawInvertRow rawInvertRow, TRawSetPixel rawSetPixel, TRawInvertPixel rawInvertPixel)
+  template <typename TPreparePixel, typename TRawFillRow, typename TRawSetPixel>
+  void genericAbsDrawLine(int X1, int Y1, int X2, int Y2, RGB888 const & color, TPreparePixel preparePixel, TRawFillRow rawFillRow, TRawSetPixel rawSetPixel)
   {
     if (paintState().penWidth > 1) {
       absDrawThickLine(X1, Y1, X2, Y2, paintState().penWidth, color);
@@ -1105,10 +1105,7 @@ protected:
         return;
       X1 = iclamp(X1, paintState().absClippingRect.X1, paintState().absClippingRect.X2);
       X2 = iclamp(X2, paintState().absClippingRect.X1, paintState().absClippingRect.X2);
-      if (paintState().paintOptions.NOT)
-        rawInvertRow(Y1, X1, X2);
-      else
-        rawFillRow(Y1, X1, X2, pattern);
+      rawFillRow(Y1, X1, X2, pattern);
     } else if (X1 == X2) {
       // vertical line
       if (X1 < paintState().absClippingRect.X1 || X1 > paintState().absClippingRect.X2)
@@ -1119,13 +1116,8 @@ protected:
         return;
       Y1 = iclamp(Y1, paintState().absClippingRect.Y1, paintState().absClippingRect.Y2);
       Y2 = iclamp(Y2, paintState().absClippingRect.Y1, paintState().absClippingRect.Y2);
-      if (paintState().paintOptions.NOT) {
-        for (int y = Y1; y <= Y2; ++y)
-          rawInvertPixel(X1, y);
-      } else {
-        for (int y = Y1; y <= Y2; ++y)
-          rawSetPixel(X1, y, pattern);
-      }
+      for (int y = Y1; y <= Y2; ++y)
+        rawSetPixel(X1, y, pattern);
     } else {
       // other cases (Bresenham's algorithm)
       // TODO: to optimize
@@ -1147,10 +1139,7 @@ protected:
       int err = (dx > dy ? dx : -dy) / 2;
       while (true) {
         if (paintState().absClippingRect.contains(X1, Y1)) {
-          if (paintState().paintOptions.NOT)
-            rawInvertPixel(X1, Y1);
-          else
-            rawSetPixel(X1, Y1, pattern);
+          rawSetPixel(X1, Y1, pattern);
         }
         if (X1 == X2 && Y1 == Y2)
           break;

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -937,7 +937,7 @@ protected:
 
   virtual void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color) = 0;
 
-  virtual void rawFillRow(int y, int x1, int x2, RGB888 color) = 0;
+  virtual void fillRow(int y, int x1, int x2, RGB888 color) = 0;
 
   virtual void drawEllipse(Size const & size, Rect & updateRect) = 0;
 

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -592,14 +592,24 @@ struct Path {
 } __attribute__ ((packed));
 
 
+enum PaintMode : uint8_t {
+  Set = 0,      // Plot colour
+  OR = 1,       // OR colour onto screen
+  AND = 2,      // AND colour onto screen
+  XOR = 3,      // XOR colour onto screen
+  Invert = 4,   // Invert colour on screen
+  NOT = 4,      // NOT colour onto screen, alias for Invert
+};
+
 /**
  * @brief Specifies general paint options.
  */
 struct PaintOptions {
   uint8_t swapFGBG : 1;  /**< If enabled swaps foreground and background colors */
   uint8_t NOT      : 1;  /**< If enabled performs NOT logical operator on destination. Implemented only for straight lines and non-filled rectangles. */
+  PaintMode mode   : 3;  /**< Paint mode */
 
-  PaintOptions() : swapFGBG(false), NOT(false) { }
+  PaintOptions() : swapFGBG(false), NOT(false), mode(PaintMode::Set) { }
 } __attribute__ ((packed));
 
 

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -539,6 +539,30 @@ struct Cursor {
 struct QuadTreeObject;
 
 
+enum PaintMode : uint8_t {
+  Set = 0,      // Plot colour
+  OR = 1,       // OR colour onto screen
+  AND = 2,      // AND colour onto screen
+  XOR = 3,      // XOR colour onto screen
+  Invert = 4,   // Invert colour on screen
+  NOT = 4,      // NOT colour onto screen, alias for Invert
+  NoOp = 5,     // No operation
+  ANDNOT = 6,   // AND colour on screen with NOT colour
+  ORNOT = 7,    // OR colour on screen with NOT colour
+};
+
+/**
+ * @brief Specifies general paint options.
+ */
+struct PaintOptions {
+  uint8_t swapFGBG : 1;  /**< If enabled swaps foreground and background colors */
+  uint8_t NOT      : 1;  /**< If enabled performs NOT logical operator on destination. Implemented only for straight lines and non-filled rectangles. */
+  PaintMode mode   : 3;  /**< Paint mode */
+
+  PaintOptions() : swapFGBG(false), NOT(false), mode(PaintMode::Set) { }
+} __attribute__ ((packed));
+
+
 /**
  * @brief Represents a sprite.
  *
@@ -559,6 +583,7 @@ struct Sprite {
   int16_t            savedBackgroundHeight;
   uint8_t *          savedBackground;
   QuadTreeObject *   collisionDetectorObject;
+  PaintOptions       paintOptions;
   struct {
     uint8_t visible:  1;
     // A static sprite should be positioned before dynamic sprites.
@@ -589,30 +614,6 @@ struct Path {
   Point const * points;
   int           pointsCount;
   bool          freePoints; // deallocate points after drawing
-} __attribute__ ((packed));
-
-
-enum PaintMode : uint8_t {
-  Set = 0,      // Plot colour
-  OR = 1,       // OR colour onto screen
-  AND = 2,      // AND colour onto screen
-  XOR = 3,      // XOR colour onto screen
-  Invert = 4,   // Invert colour on screen
-  NOT = 4,      // NOT colour onto screen, alias for Invert
-  NoOp = 5,     // No operation
-  ANDNOT = 6,   // AND colour on screen with NOT colour
-  ORNOT = 7,    // OR colour on screen with NOT colour
-};
-
-/**
- * @brief Specifies general paint options.
- */
-struct PaintOptions {
-  uint8_t swapFGBG : 1;  /**< If enabled swaps foreground and background colors */
-  uint8_t NOT      : 1;  /**< If enabled performs NOT logical operator on destination. Implemented only for straight lines and non-filled rectangles. */
-  PaintMode mode   : 3;  /**< Paint mode */
-
-  PaintOptions() : swapFGBG(false), NOT(false), mode(PaintMode::Set) { }
 } __attribute__ ((packed));
 
 


### PR DESCRIPTION
Adds several new paint modes that can be set in PaintOptions

These modes mirror the GCOL actions supported from Acorn's graphics system - actions 0-7, as supported by RISC OS (which encompasses the 0-4 supported by the Beeb).

Todo:

- [x] VScroll (uses rawFillRow with colour, not pattern)
- [x] triple-check uses of rawFillRow
- [x] vgacontroller2
- [x] vgacontroller4
- [x] vgacontrolelr8
- [x] vgacontroller16
- [x] rename rawFillRow
- [x] remove unnecessary args from genericAbsDrawLine
- [x] work out what to do about NOT
  - keeping it for now, only supported on "line" commands, as before
  - for proper NOT support set a painting mode
- [x] fix CLG
  - RISC OS example in docs has `GCOL 4,128: CLG` to invert the graphics window, which doesn't work on Agon
  - fix done - minor change needed in agon-vdp
  - fix incomplete, as we should track fg/bg GCOL modes separately within agon-vdp
- [x] text?
  - currently not supported
  - what did the Beeb, and RISC OS, do with text rendering and GCOL modes?
- [x] bitmap plots?
- [x] line-fill plots
  - these needed some bug fixes agon-vdp side to fully match Acorn
  - plots have not been optimised and remain very slow 
- [x] rectangle copy/move plots?