### PR TITLE
Arcs, segments, and sectors

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -389,6 +389,20 @@ void Canvas::drawArc(int X, int Y, int X1, int Y1, int X2, int Y2)
 }
 
 
+void Canvas::fillSegment(int X, int Y, int X1, int Y1, int X2, int Y2)
+{
+  moveTo(X, Y);
+  Primitive p;
+  p.cmd  = PrimitiveCmd::FillSegment;
+  // Use a Rect as a convenience to pass 2 points
+  // NB arc is always drawn anti-clockwise, with X1,Y1 as the start point
+  // and X2,Y2 as the end point, which is used to calculate the angle
+  // (i.e. the end point does not have to lie on circumference)
+  p.rect = Rect(X1, Y1, X2, Y2);
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::drawGlyph(int X, int Y, int width, int height, uint8_t const * data, int index)
 {
   Primitive p;

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -375,6 +375,20 @@ void Canvas::drawEllipse(int X, int Y, int width, int height)
 }
 
 
+void Canvas::drawArc(int X, int Y, int X1, int Y1, int X2, int Y2)
+{
+  moveTo(X, Y);
+  Primitive p;
+  p.cmd  = PrimitiveCmd::DrawArc;
+  // Use a Rect as a convenience to pass 2 points
+  // NB arc is always drawn anti-clockwise, with X1,Y1 as the start point
+  // and X2,Y2 as the end point, which is used to calculate the angle
+  // (i.e. the end point does not have to lie on circumference)
+  p.rect = Rect(X1, Y1, X2, Y2);
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::drawGlyph(int X, int Y, int width, int height, uint8_t const * data, int index)
 {
   Primitive p;

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -237,6 +237,42 @@ void Canvas::setLineEnds(LineEnds value)
 }
 
 
+void Canvas::setLinePattern(LinePattern & value)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLinePattern;
+  p.linePattern = value;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::setLinePatternLength(uint8_t value)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLinePatternLength;
+  p.ivalue = value;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::setLinePatternOffset(uint8_t value)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLinePatternOffset;
+  p.ivalue = value;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::setLineOptions(LineOptions options)
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::SetLineOptions;
+  p.lineOptions = options;
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::setBrushColor(RGB888 const & color)
 {
   Primitive p;

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -403,6 +403,20 @@ void Canvas::fillSegment(int X, int Y, int X1, int Y1, int X2, int Y2)
 }
 
 
+void Canvas::fillSector(int X, int Y, int X1, int Y1, int X2, int Y2)
+{
+  moveTo(X, Y);
+  Primitive p;
+  p.cmd  = PrimitiveCmd::FillSector;
+  // Use a Rect as a convenience to pass 2 points
+  // NB arc is always drawn anti-clockwise, with X1,Y1 as the start point
+  // and X2,Y2 as the end point, which is used to calculate the angle
+  // (i.e. the end point does not have to lie on circumference)
+  p.rect = Rect(X1, Y1, X2, Y2);
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::drawGlyph(int X, int Y, int width, int height, uint8_t const * data, int index)
 {
   Primitive p;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -543,6 +543,20 @@ public:
   void drawArc(int X, int Y, int X1, int Y1, int X2, int Y2);
 
   /**
+   * @brief Draws a filled segment of a circle specifying center, start and endpoints, using current brush color.
+   *        The circle arc is drawn anticlockwise.
+   *        The endpoint is used to work out the angle to the end point of the arc, rather than being on the arc itself.
+   * 
+   * @param X Horizontal coordinate of the circle center.
+   * @param Y Vertical coordinate of the circle center.
+   * @param X1 Horizontal coordinate of the start point.
+   * @param Y1 Vertical coordinate of the start point.
+   * @param X2 Horizontal coordinate of the end point.
+   * @param Y2 Vertical coordinate of the end point.
+  */
+  void fillSegment(int X, int Y, int X1, int Y1, int X2, int Y2);
+
+  /**
    * @brief Fills an ellipse specifying center and size, using current brush color.
    *
    * @param X Horizontal coordinate of the ellipse center.

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -318,6 +318,50 @@ public:
   void setLineEnds(LineEnds value);
 
   /**
+   * @brief Sets line pattern
+   * 
+   * @param value Line pattern.
+   * 
+   * Example:
+   * 
+   *    Canvas.setLinePattern(pattern)
+  */
+  void setLinePattern(LinePattern & value);
+
+  /**
+   * @brief Sets line pattern length
+   * 
+   * @param value Line pattern length.
+   * 
+   * Example:
+   * 
+   *   Canvas.setLinePatternLength(length)
+  */
+  void setLinePatternLength(uint8_t value);
+
+  /**
+   * @brief Sets offset position within the line pattern
+   * 
+   * @param value offset position.
+   * 
+   * Example:
+   * 
+   *    Canvas.setLinePatternOffset(position)
+  */
+  void setLinePatternOffset(uint8_t value);
+
+  /**
+   * @brief Sets line drawing options
+   * 
+   * @param value Line drawing options.
+   * 
+   * Example:
+   * 
+   *    Canvas.setLineOptions(LineOptions().Antialias(true).Smooth(true));
+   */
+  void setLineOptions(LineOptions value);
+
+  /**
    * @brief Fills a single pixel with the pen color.
    *
    * @param X Horizontal pixel position.

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -557,6 +557,20 @@ public:
   void fillSegment(int X, int Y, int X1, int Y1, int X2, int Y2);
 
   /**
+   * @brief Draws a filled sector of a circle specifying center, start and endpoints, using current brush color.
+   *        The circle arc is drawn anticlockwise.
+   *        The endpoint is used to work out the angle to the end point of the arc, rather than being on the arc itself.
+   * 
+   * @param X Horizontal coordinate of the circle center.
+   * @param Y Vertical coordinate of the circle center.
+   * @param X1 Horizontal coordinate of the start point.
+   * @param Y1 Vertical coordinate of the start point.
+   * @param X2 Horizontal coordinate of the end point.
+   * @param Y2 Vertical coordinate of the end point.
+  */
+  void fillSector(int X, int Y, int X1, int Y1, int X2, int Y2);
+
+  /**
    * @brief Fills an ellipse specifying center and size, using current brush color.
    *
    * @param X Horizontal coordinate of the ellipse center.

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -531,6 +531,18 @@ public:
   void drawEllipse(int X, int Y, int width, int height);
 
   /**
+   * @brief Draws an anticlockwise arc of a circle specifying center, start and endpoints, using current pen color.
+   * 
+   * @param X Horizontal coordinate of the circle center.
+   * @param Y Vertical coordinate of the circle center.
+   * @param X1 Horizontal coordinate of the start point.
+   * @param Y1 Vertical coordinate of the start point.
+   * @param X2 Horizontal coordinate of the end point.
+   * @param Y2 Vertical coordinate of the end point.
+  */
+  void drawArc(int X, int Y, int X1, int Y1, int X2, int Y2);
+
+  /**
    * @brief Fills an ellipse specifying center and size, using current brush color.
    *
    * @param X Horizontal coordinate of the ellipse center.

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -378,6 +378,13 @@ void VGA16Controller::drawArc(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA16Controller::fillSegment(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSegment(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA16Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -371,6 +371,13 @@ void VGA16Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA16Controller::drawArc(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawArc(rect, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA16Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -385,6 +385,13 @@ void VGA16Controller::fillSegment(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA16Controller::fillSector(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSector(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA16Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -140,6 +140,9 @@ private:
   void fillSegment(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSector(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -134,6 +134,9 @@ private:
   void drawEllipse(Size const & size, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void drawArc(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -137,6 +137,9 @@ private:
   void drawArc(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSegment(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -359,6 +359,13 @@ void VGA2Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA2Controller::drawArc(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawArc(rect, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA2Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -373,6 +373,13 @@ void VGA2Controller::fillSegment(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA2Controller::fillSector(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSector(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA2Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -366,6 +366,13 @@ void VGA2Controller::drawArc(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA2Controller::fillSegment(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSegment(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA2Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -136,6 +136,9 @@ private:
   void drawEllipse(Size const & size, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void drawArc(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -142,6 +142,9 @@ private:
   void fillSegment(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSector(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -139,6 +139,9 @@ private:
   void drawArc(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSegment(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -403,6 +403,13 @@ void VGA4Controller::fillSegment(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA4Controller::fillSector(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSector(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA4Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -389,6 +389,13 @@ void VGA4Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA4Controller::drawArc(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawArc(rect, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA4Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -396,6 +396,13 @@ void VGA4Controller::drawArc(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA4Controller::fillSegment(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSegment(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA4Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -133,6 +133,9 @@ private:
   void drawEllipse(Size const & size, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void drawArc(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -139,6 +139,9 @@ private:
   void fillSegment(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSector(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -136,6 +136,9 @@ private:
   void drawArc(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSegment(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -372,6 +372,13 @@ void VGA8Controller::fillSegment(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA8Controller::fillSector(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSector(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA8Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -358,6 +358,13 @@ void VGA8Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA8Controller::drawArc(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawArc(rect, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA8Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -365,6 +365,13 @@ void VGA8Controller::drawArc(Rect const & rect, Rect & updateRect)
 }
 
 
+void VGA8Controller::fillSegment(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSegment(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void VGA8Controller::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -143,6 +143,9 @@ private:
   void fillSegment(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSector(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -137,6 +137,9 @@ private:
   void drawEllipse(Size const & size, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void drawArc(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -140,6 +140,9 @@ private:
   void drawArc(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSegment(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -375,6 +375,13 @@ void IRAM_ATTR VGAController::fillSegment(Rect const & rect, Rect & updateRect)
 }
 
 
+void IRAM_ATTR VGAController::fillSector(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSector(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void IRAM_ATTR VGAController::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -361,6 +361,13 @@ void IRAM_ATTR VGAController::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void IRAM_ATTR VGAController::drawArc(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawArc(rect, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void IRAM_ATTR VGAController::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -368,6 +368,13 @@ void IRAM_ATTR VGAController::drawArc(Rect const & rect, Rect & updateRect)
 }
 
 
+void IRAM_ATTR VGAController::fillSegment(Rect const & rect, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericFillSegment(rect, updateRect, getPixelLambda(mode), fillRowLambda(mode));
+}
+
+
 void IRAM_ATTR VGAController::clear(Rect & updateRect)
 {
   hideSprites(updateRect);

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -214,6 +214,9 @@ private:
   void drawEllipse(Size const & size, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void drawArc(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -220,6 +220,9 @@ private:
   void fillSegment(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSector(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -217,6 +217,9 @@ private:
   void drawArc(Rect const & rect, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
+  void fillSegment(Rect const & rect, Rect & updateRect);
+
+  // abstract method of BitmappedDisplayController
   void clear(Rect & updateRect);
 
   // abstract method of BitmappedDisplayController

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -749,6 +749,9 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
     case PrimitiveCmd::DrawArc:
       drawArc(prim.rect, updateRect);
       break;
+    case PrimitiveCmd::FillSegment:
+      fillSegment(prim.rect, updateRect);
+      break;
     case PrimitiveCmd::Clear:
       updateRect = updateRect.merge(Rect(0, 0, getViewPortWidth() - 1, getViewPortHeight() - 1));
       clear(updateRect);

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -418,6 +418,9 @@ void IRAM_ATTR BitmappedDisplayController::resetPaintState()
   m_paintState.absClippingRect       = m_paintState.clippingRect;
   m_paintState.penWidth              = 1;
   m_paintState.lineEnds              = LineEnds::None;
+  m_paintState.linePattern           = LinePattern();
+  m_paintState.lineOptions           = LineOptions();
+  m_paintState.linePatternLength     = 8;
 }
 
 
@@ -817,6 +820,18 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
       break;
     case PrimitiveCmd::SetLineEnds:
       paintState().lineEnds = prim.lineEnds;
+      break;
+    case PrimitiveCmd::SetLinePattern:
+      paintState().linePattern = prim.linePattern;
+      break;
+    case PrimitiveCmd::SetLinePatternLength:
+      paintState().linePatternLength = imin(64, imax(1, prim.ivalue));
+      break;
+    case PrimitiveCmd::SetLinePatternOffset:
+      paintState().linePattern.offset = prim.ivalue % paintState().linePatternLength;
+      break;
+    case PrimitiveCmd::SetLineOptions:
+      paintState().lineOptions = prim.lineOptions;
       break;
   }
 }

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -752,6 +752,9 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
     case PrimitiveCmd::FillSegment:
       fillSegment(prim.rect, updateRect);
       break;
+    case PrimitiveCmd::FillSector:
+      fillSector(prim.rect, updateRect);
+      break;
     case PrimitiveCmd::Clear:
       updateRect = updateRect.merge(Rect(0, 0, getViewPortWidth() - 1, getViewPortHeight() - 1));
       clear(updateRect);

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -746,6 +746,9 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
     case PrimitiveCmd::DrawEllipse:
       drawEllipse(prim.size, updateRect);
       break;
+    case PrimitiveCmd::DrawArc:
+      drawArc(prim.rect, updateRect);
+      break;
     case PrimitiveCmd::Clear:
       updateRect = updateRect.merge(Rect(0, 0, getViewPortWidth() - 1, getViewPortHeight() - 1));
       clear(updateRect);

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -37,6 +37,7 @@
 
 
 #include <functional>
+#include <vector>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -119,6 +120,10 @@ enum PrimitiveCmd : uint8_t {
   // Draw a filled segment from a circle, current position is the center, using current brush color
   // params: rect (providing a startPoint and endPoint)
   FillSegment,
+
+  // Draw a filled sector of a circle, current position is the center, using current brush color
+  // params: rect (providing a startPoint and endPoint)
+  FillSector,
 
   // Fill viewport with brush color
   // params: none
@@ -995,6 +1000,8 @@ protected:
 
   virtual void fillSegment(Rect const & rect, Rect & updateRect) = 0;
 
+  virtual void fillSector(Rect const & rect, Rect & updateRect) = 0;
+
   virtual void clear(Rect & updateRect) = 0;
 
   virtual void VScroll(int scroll, Rect & updateRect) = 0;
@@ -1432,17 +1439,21 @@ protected:
     int maxX = -999999;
     chordDeltaInfo.newRowCheck(y);
 
-    std::function<void()> finishRow = [&minX, &maxX, &y, &err, &clipX1, &clipX2, &clipY1, &clipY2, &chordDeltaInfo, &centerX, &centerY, &pattern, &rawFillRow] () {
-      int row = centerY + y;
+    std::function<void(int, int, int)> drawRow = [&rawFillRow, &clipX1, &clipX2, &pattern] (int row, int minX, int maxX) {
+      if (minX <= clipX2 && maxX >= clipX1) {
+        const int X1 = iclamp(minX, clipX1, clipX2);
+        const int X2 = iclamp(maxX, clipX1, clipX2);
+        rawFillRow(row, X1, X2, pattern);
+      }
+    };
+
+    std::function<void()> finishRow = [&minX, &maxX, &y, &err, &clipX1, &clipX2, &clipY1, &clipY2, &chordDeltaInfo, &centerX, &centerY, &drawRow] () {
+      const int row = centerY + y;
       if (minX <= maxX && row >= clipY1 && row <= clipY2) {
         if (chordDeltaInfo.hasPixels) {
-          int X1 = iclamp(centerX + imin(minX, chordDeltaInfo.minX), clipX1, clipX2);
-          int X2 = iclamp(centerX + imax(maxX, chordDeltaInfo.maxX), clipX1, clipX2);
-          rawFillRow(row, X1, X2, pattern);
+          drawRow(row, centerX + imin(minX, chordDeltaInfo.minX), centerX + imax(maxX, chordDeltaInfo.maxX));
         } else {
-          int X1 = iclamp(centerX + minX, clipX1, clipX2);
-          int X2 = iclamp(centerX + maxX, clipX1, clipX2);
-          rawFillRow(row, X1, X2, pattern);
+          drawRow(row, centerX + minX, centerX + maxX);
         }
       }
       err += ++y*2+1;
@@ -1503,8 +1514,281 @@ protected:
           err += ++x*2+1;
         }/* e_xy+e_x > 0 or no 2nd y-step */
       } while (x < 0);
+      finishRow();
     }
-    finishRow();
+  }
+
+
+  // Sector drawn using modified Alois Zingl's algorith, which is a modified Bresenham's algorithm
+  template <typename TPreparePixel, typename TRawFillRow>
+  void genericFillSector(Rect const & rect, Rect & updateRect, TPreparePixel preparePixel, TRawFillRow rawFillRow)
+  {
+    auto pattern = preparePixel(getActualBrushColor());
+
+    const int clipX1 = paintState().absClippingRect.X1;
+    const int clipY1 = paintState().absClippingRect.Y1;
+    const int clipX2 = paintState().absClippingRect.X2;
+    const int clipY2 = paintState().absClippingRect.Y2;
+
+    const int centerX = paintState().position.X;
+    const int centerY = paintState().position.Y;
+
+    LineInfo startInfo = LineInfo(centerX, centerY, rect.X1, rect.Y1);
+    LineInfo endInfo = LineInfo(centerX, centerY, rect.X2, rect.Y2);
+    const int radius = startInfo.length();
+
+    QuadrantInfo quadrants[4] = {
+      QuadrantInfo(0, startInfo, endInfo),
+      QuadrantInfo(1, startInfo, endInfo),
+      QuadrantInfo(2, startInfo, endInfo),
+      QuadrantInfo(3, startInfo, endInfo)
+    };
+
+    LineInfo startLine = LineInfo(0, 0, startInfo.deltaX, startInfo.deltaY);
+    LineInfo endWalked = endInfo.walkDistance(radius);
+    LineInfo endLine = LineInfo(0, 0, endWalked.deltaX, endWalked.deltaY);
+    const bool startLeftmost = startLine.deltaX < endLine.deltaX;
+    startLine.sortByY();
+    endLine.sortByY();
+
+    // Simplistic updateRect, using whole bounding box of circle
+    updateRect = updateRect.merge(Rect(centerX - radius, centerY - radius, centerX + radius, centerY + radius));
+    hideSprites(updateRect);
+
+    int r = radius;
+    int x = 0;
+    int y = -r;
+    int err = 2 - 2*r;
+    int lMinX = 999999;
+    int lMaxX = -999999;
+    int rMinX = 999999;
+    int rMaxX = -999999;
+    startLine.newRowCheck(y);
+    endLine.newRowCheck(y);
+    bool shownLeftEdge = false;
+    bool shownRightEdge = false;
+    bool shownStartLine = false;
+    bool shownEndLine = false;
+
+    std::function<void(int, int, int)> drawRow = [&rawFillRow, &clipX1, &clipX2, &pattern] (int row, int minX, int maxX) {
+      if (minX <= clipX2 && maxX >= clipX1) {
+        const int X1 = iclamp(minX, clipX1, clipX2);
+        const int X2 = iclamp(maxX, clipX1, clipX2);
+        rawFillRow(row, X1, X2, pattern);
+      }
+    };
+
+    // finishRow will draw a row if it's inside the clipping rectangle, and advance to the next row
+    // for drawing, the most important line is the circle outline
+    // start/end lines will only be drawn if they are inside the outline
+    std::function<void(bool const)> finishRow = [
+      &startLeftmost, &shownLeftEdge, &shownRightEdge, &shownStartLine, &shownEndLine,
+      &lMinX, &lMaxX, &rMinX, &rMaxX, &y, &err, 
+      &clipX1, &clipX2, &clipY1, &clipY2, &startLine, &endLine, 
+      &centerX, &centerY, &pattern, &drawRow
+    ] (bool const upperHalf) {
+      int const row = centerY + y;
+      bool const hasLeftEdge = lMinX <= 0;
+      bool const hasRightEdge = rMaxX >= 0;
+      std::vector<int> rowPixels;
+
+      if (row >= clipY1 && row <= clipY2 && (hasLeftEdge || hasRightEdge || startLine.hasPixels || endLine.hasPixels)) {
+        if (hasLeftEdge) {
+          rowPixels.push_back(lMinX);
+        }
+
+        bool hasStartLine = startLine.hasPixels;
+        bool hasEndLine = endLine.hasPixels;        
+
+        // keep track of whether we've shown the left or right edge of circle
+        shownLeftEdge = shownLeftEdge || hasLeftEdge;
+        shownRightEdge = shownRightEdge || hasRightEdge;
+
+        // work out if we should _really_ be drawing start/end lines
+        // lines can be slightly too long owing to integer rounding issues
+        if (upperHalf) {
+          // in the upper half, we need to prevent start/end lines from being drawn if they are outside the circle
+          // so for new lines only we check to see if there is an edge on that side of the circle
+          if (hasStartLine && !shownStartLine) {
+            hasStartLine = startLine.x < 0 ? hasLeftEdge : hasRightEdge;
+          }
+          if (hasEndLine && !shownEndLine) {
+            hasEndLine = endLine.x < 0 ? hasLeftEdge : hasRightEdge;
+          }
+        } else {
+          // in the lower half we need to stop drawing start/end lines if they are outside the circle
+          // care must be taken tho to ensure we draw lines that just fill between start and end lines
+          // so this means stopping lines when corresponding edge had been shown and no longer exists
+          if (shownLeftEdge && !hasLeftEdge) {
+            if (hasEndLine && endLine.x < 0 && (!hasRightEdge || !startLeftmost)) {
+              hasEndLine = false;
+            }
+            if (hasStartLine && startLine.x < 0 && (!hasRightEdge || startLeftmost)) {
+              hasStartLine = false;
+            }
+          }
+          
+          if (shownRightEdge && !hasRightEdge) {
+            if (hasEndLine && startLeftmost && endLine.x > 0) {
+              hasEndLine = false;
+            }
+            if (hasStartLine && !startLeftmost && startLine.x > 0) {
+              hasStartLine = false;
+            }
+          }
+        }
+        
+        shownStartLine = shownStartLine || hasStartLine;
+        shownEndLine = shownEndLine || hasEndLine;
+
+        if (hasStartLine) {
+          if (hasEndLine) {
+            // if we're in the upper half, then having start line leftmost means we have two parts to the row
+            // or in the bottom half, rightmost means we have two parts to the row
+            auto const firstLine = startLeftmost ? startLine : endLine;
+            auto const secondLine = startLeftmost ? endLine : startLine;
+
+            if (hasStartLine && hasEndLine && hasLeftEdge && hasRightEdge && (startLeftmost ^ !upperHalf)) {
+              // there are two parts to the row
+              // we may have started a line, but not finished it
+              if (!hasLeftEdge) {
+                // first line
+                rowPixels.push_back(firstLine.minX);
+              }
+              // close off first line
+              rowPixels.push_back(firstLine.maxX);
+
+              // then push left edge of right-most line
+              rowPixels.push_back(hasRightEdge ? imin(secondLine.minX, rMinX) : secondLine.minX);
+              rowPixels.push_back(hasRightEdge ? rMaxX : secondLine.maxX);
+            } else {
+              // there is only one part to the row
+              // which should be first line to second line
+              if (!hasLeftEdge) {
+                rowPixels.push_back(firstLine.minX);
+              }
+              rowPixels.push_back(hasRightEdge ? rMaxX : secondLine.maxX);
+            }
+          } else {
+            // have start line, but no end line
+            if (!hasLeftEdge) {
+              rowPixels.push_back(startLine.minX);
+            }
+
+            rowPixels.push_back(hasRightEdge ? rMaxX : startLine.maxX);
+          }
+        } else if (hasEndLine) {
+          if (!hasLeftEdge) {
+            rowPixels.push_back(endLine.minX);
+          }
+          rowPixels.push_back(hasRightEdge ? rMaxX : endLine.maxX);
+        } else {
+          // no start or end lines
+          if (hasRightEdge) {
+            if (!hasLeftEdge) {
+              rowPixels.push_back(rMinX);
+            }
+            rowPixels.push_back(rMaxX);
+          }
+        }
+
+        if (rowPixels.size() % 2 == 1) {
+          if (hasLeftEdge) {
+            rowPixels.push_back(lMaxX);
+          } else {
+            // double up on last pixel just to make sure we have a "line"
+            // in principle this shouldn't be possible, but just in case
+            rowPixels.push_back(rowPixels[rowPixels.size() - 1]);
+          }
+        }
+        
+        if (rowPixels.size() >= 2) {
+          if (rowPixels.size() == 4 && rowPixels[1] == rowPixels[2]) {
+            // conjoining lines, so just draw one line
+            drawRow(row, centerX + rowPixels[0], centerX + rowPixels[3]);
+          } else {
+            drawRow(row, centerX + rowPixels[0], centerX + rowPixels[1]);
+            if (rowPixels.size() == 4) {
+              drawRow(row, centerX + rowPixels[2], centerX + rowPixels[3]);
+            }
+          }
+        }
+      }
+
+      err += ++y*2+1;
+      lMinX = 999999;
+      lMaxX = -999999;
+      rMinX = 999999;
+      rMaxX = -999999;
+      startLine.newRowCheck(y);
+      endLine.newRowCheck(y);
+    };
+
+    // we can skip showing top half of circle if segment is entirely in the bottom half
+    if (quadrants[0].showNothing && quadrants[1].showNothing) {
+      // Skip top half
+      y = 0;
+      startLine.newRowCheck(y);
+      endLine.newRowCheck(y);
+    } else {
+      do {
+        if (quadrantContainsArcPixel(quadrants[0], startInfo, endInfo, x, y)) {
+          rMinX = imin(rMinX, x);
+          rMaxX = imax(rMaxX, x);
+        }
+        if (quadrantContainsArcPixel(quadrants[1], startInfo, endInfo, -x, y)) {
+          lMinX = imin(lMinX, -x);
+          lMaxX = imax(lMaxX, -x);
+        }
+        startLine.walkToY(y);
+        endLine.walkToY(y);
+
+        r = err;
+        if (r <= x) {
+          x += 1;
+          err += x*2+1;           /* e_xy+e_x < 0 */
+        }
+        if (r > y || err > x) {
+          finishRow(true);
+        }/* e_xy+e_y > 0 or no 2nd y-step */
+      } while (y < 0);
+    }
+
+    shownLeftEdge = false;
+    shownRightEdge = false;
+
+    // draw lower half - this time walking from x = -r to x = 0
+    if (quadrants[2].showNothing && quadrants[3].showNothing) {
+      // skip the bottom
+      // y = radius;
+      finishRow(true);
+    } else {
+      r = radius;
+      x = -radius;
+      y = 0;
+      err = 2 - 2*r; /* II. Quadrant */ 
+      do {
+        if (quadrantContainsArcPixel(quadrants[2], startInfo, endInfo, x, y)) {
+          lMinX = imin(lMinX, x);
+          lMaxX = imax(lMaxX, x);
+        }
+        if (quadrantContainsArcPixel(quadrants[3], startInfo, endInfo, -x, y)) {
+          rMinX = imin(rMinX, -x);
+          rMaxX = imax(rMaxX, -x);
+        }
+        startLine.walkToY(y);
+        endLine.walkToY(y);
+
+        r = err;
+        if (r <= y) {
+          finishRow(false);
+        }
+        if (r > x || err > y) {
+          err += ++x*2+1;
+        }/* e_xy+e_x > 0 or no 2nd y-step */
+      } while (x < 0);
+      finishRow(false);
+    }
   }
 
 

--- a/src/fabutils.cpp
+++ b/src/fabutils.cpp
@@ -387,7 +387,7 @@ uint8_t getCircleQuadrant(int x, int y) {
     }
     return 1;
   }
-  if (y < 0) {
+  if (y <= 0) {
     return 0;
   }
   return 3;
@@ -403,17 +403,17 @@ bool quadrantContainsArcPixel(QuadrantInfo & quadrant, LineInfo & start, LineInf
     if (quadrant.containsStart) {
       auto slopeTest = start.absDeltaY * abs(x);
       if (quadrant.isEven) {
-        drawing = slopeTest < (start.absDeltaX * abs(y));
+        drawing = slopeTest <= (start.absDeltaX * abs(y));
       } else {
-        drawing = slopeTest > (start.absDeltaX * abs(y));
+        drawing = slopeTest >= (start.absDeltaX * abs(y));
       }
       if (quadrant.containsEnd) {
         slopeTest = end.absDeltaY * abs(x);
         bool drawingEnd = false;
         if (quadrant.isEven) {
-          drawingEnd = (slopeTest > (end.absDeltaX * abs(y)));
+          drawingEnd = (slopeTest >= (end.absDeltaX * abs(y)));
         } else {
-          drawingEnd = (slopeTest < (end.absDeltaX * abs(y)));
+          drawingEnd = (slopeTest <= (end.absDeltaX * abs(y)));
         }
         if (quadrant.containsStart && quadrant.containsEnd) {
           if (quadrant.startCloserToHorizontal ^ quadrant.isEven) {
@@ -426,9 +426,9 @@ bool quadrantContainsArcPixel(QuadrantInfo & quadrant, LineInfo & start, LineInf
     } else if (quadrant.containsEnd) {
       auto slopeTest = end.absDeltaY * abs(x);
       if (quadrant.isEven) {
-        return slopeTest > (end.absDeltaX * abs(y));
+        return slopeTest >= (end.absDeltaX * abs(y));
       } else {
-        return slopeTest < (end.absDeltaX * abs(y));
+        return slopeTest <= (end.absDeltaX * abs(y));
       }
     }
   }

--- a/src/fabutils.cpp
+++ b/src/fabutils.cpp
@@ -380,6 +380,62 @@ bool getBit(uint8_t* array, size_t bitIndex) {
 }
 
 
+uint8_t getCircleQuadrant(int x, int y) {
+  if (x < 0) {
+    if (y > 0) {
+      return 2;
+    }
+    return 1;
+  }
+  if (y < 0) {
+    return 0;
+  }
+  return 3;
+}
+
+
+bool quadrantContainsArcPixel(QuadrantInfo & quadrant, LineInfo & start, LineInfo & end, int16_t x, int16_t y) {
+  // Work out whether our arc circumference pixel should be shown in this quadrant
+  bool drawing = false;
+  if (quadrant.showAll) {
+    return true;
+  } else if (!quadrant.noArc) {
+    if (quadrant.containsStart) {
+      auto slopeTest = start.absDeltaY * abs(x);
+      if (quadrant.isEven) {
+        drawing = slopeTest < (start.absDeltaX * abs(y));
+      } else {
+        drawing = slopeTest > (start.absDeltaX * abs(y));
+      }
+      if (quadrant.containsEnd) {
+        slopeTest = end.absDeltaY * abs(x);
+        bool drawingEnd = false;
+        if (quadrant.isEven) {
+          drawingEnd = (slopeTest > (end.absDeltaX * abs(y)));
+        } else {
+          drawingEnd = (slopeTest < (end.absDeltaX * abs(y)));
+        }
+        if (quadrant.containsStart && quadrant.containsEnd) {
+          if (quadrant.startCloserToHorizontal ^ quadrant.isEven) {
+            return drawing || drawingEnd;
+          } else {
+            return drawing && drawingEnd;
+          }
+        }
+      }
+    } else if (quadrant.containsEnd) {
+      auto slopeTest = end.absDeltaY * abs(x);
+      if (quadrant.isEven) {
+        return slopeTest > (end.absDeltaX * abs(y));
+      } else {
+        return slopeTest < (end.absDeltaX * abs(y));
+      }
+    }
+  }
+  return drawing;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////////
 // rgb222_to_hsv
 // R, G, B in the 0..3 range

--- a/src/fabutils.cpp
+++ b/src/fabutils.cpp
@@ -373,6 +373,13 @@ Rect IRAM_ATTR Rect::intersection(Rect const & rect) const
 }
 
 
+bool getBit(uint8_t* array, size_t bitIndex) {
+    size_t byteIndex = bitIndex / 8;
+    int bitPosition = 7 - (bitIndex % 8);
+    return (array[byteIndex] >> bitPosition) & 1;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////////
 // rgb222_to_hsv
 // R, G, B in the 0..3 range

--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -331,8 +331,10 @@ struct LineInfo {
     deltaY = Y2 - Y1;
     absDeltaX = deltaX < 0 ? -deltaX : deltaX;
     absDeltaY = deltaY < 0 ? -deltaY : deltaY;
-    sx = deltaX < 0 ? -1 : 1;
-    sy = deltaY < 0 ? -1 : 1;
+    // sx = deltaX < 0 ? -1 : 1;
+    // sy = deltaY < 0 ? -1 : 1;
+    sx = X1 < X2 ? 1 : -1;
+    sy = Y1 <= Y2 ? 1 : -1;
     error = absDeltaX - absDeltaY;
     err = error;
     int16_t midX = (X1 + X2) / 2;
@@ -398,7 +400,8 @@ struct LineInfo {
         }
         if (e2 <= absDeltaX) {
           err += absDeltaX;
-          y += sy;
+          // y += sy;
+          y += 1;
           if (y <= newY) {
             minX = x;
             maxX = x;

--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -327,8 +327,6 @@ struct LineInfo {
   void reset() {
     x = X1;
     y = Y1;
-    minX = X1;
-    maxX = X1;
     deltaX = X2 - X1;
     deltaY = Y2 - Y1;
     absDeltaX = deltaX < 0 ? -deltaX : deltaX;
@@ -353,12 +351,12 @@ struct LineInfo {
     if (Y1 > Y2) {
       tswap(X1, X2);
       tswap(Y1, Y2);
-      reset();
     }
+    reset();
   }
 
   /* Walk a distance using Bresenham's algorithm, and return a new line */
-  LineInfo * walkDistance(int16_t distance) {
+  LineInfo walkDistance(int16_t distance) {
     int32_t dSquared = distance * distance;
     auto dy = -absDeltaY;
     auto x = 0;
@@ -376,13 +374,13 @@ struct LineInfo {
         y += sy;
       }
     }
-    return new LineInfo(X1, Y1, X1 + x, Y1 + y, CX, CY);
+    return LineInfo(X1, Y1, X1 + x, Y1 + y, CX, CY);
   }
 
   void walkToY(int16_t newY) {
     // walks to specific y value - must be used in association with newRowCheck and sortByY
     // can only be used for incremetal y values, as this assumes we're walking downwards
-    if (sx < 0) return;
+    if (sy < 0) return;
     if (hasPixels && y <= newY) {
       minX = imin(minX, x);
       maxX = imax(maxX, x);

--- a/src/fabutils.h
+++ b/src/fabutils.h
@@ -175,6 +175,9 @@ T moveItems(T dest, T src, size_t n)
 }
 
 
+bool getBit(uint8_t* array, size_t bitIndex);
+
+
 void rgb222_to_hsv(int R, int G, int B, double * h, double * s, double * v);
 
 


### PR DESCRIPTION
Adds support for operations to draw arcs, filled segments, and filled sectors.

These drawing operations are implemented to be equivalent to the corresponding Acorn PLOT codes, so command parameters for these three commands require a circle centre point, a start point (used to work out the circle radius), and an end point.  The end point is used to work out the angle of arc, and does not have to be on the circle circumference.

(This PR includes code changes from #8)