### PR TITLE
transformed bitmap plotting

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -598,22 +598,26 @@ void Canvas::copyToBitmap(int srcX, int srcY, Bitmap const * bitmap)
 }
 
 
-void Canvas::drawTransformedBitmap(int X, int Y, Bitmap const * bitmap, float const transform[9])
+void Canvas::drawTransformedBitmap(int X, int Y, Bitmap const * bitmap, float const * transform, float const * invTransform)
 {
   Primitive p;
   p.cmd               = PrimitiveCmd::DrawTransformedBitmap;
-  auto matrix = dspm::Mat(3, 3);
-  matrix(0, 0) = transform[0];
-  matrix(0, 1) = transform[1];
-  matrix(0, 2) = transform[2];
-  matrix(1, 0) = transform[3];
-  matrix(1, 1) = transform[4];
-  matrix(1, 2) = transform[5];
-  matrix(2, 0) = 0.0f;
-  matrix(2, 1) = 0.0f;
-  matrix(2, 2) = 1.0f;
-  dspm::Mat invMatrix = matrix.inverse();
-  p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(X, Y, bitmap, transform, invMatrix.data);
+  if (invTransform == nullptr) {
+    auto matrix = dspm::Mat(3, 3);
+    matrix(0, 0) = transform[0];
+    matrix(0, 1) = transform[1];
+    matrix(0, 2) = transform[2];
+    matrix(1, 0) = transform[3];
+    matrix(1, 1) = transform[4];
+    matrix(1, 2) = transform[5];
+    matrix(2, 0) = 0.0f;
+    matrix(2, 1) = 0.0f;
+    matrix(2, 2) = 1.0f;
+    dspm::Mat invMatrix = matrix.inverse();
+    p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(X, Y, bitmap, transform, invMatrix.data);
+  } else {
+    p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(X, Y, bitmap, transform, invTransform);
+  }
   m_displayController->addPrimitive(p);
 }
 

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -598,7 +598,7 @@ void Canvas::copyToBitmap(int srcX, int srcY, Bitmap const * bitmap)
 }
 
 
-void Canvas::drawTransformedBitmap(Bitmap const * bitmap, float const transform[9])
+void Canvas::drawTransformedBitmap(int X, int Y, Bitmap const * bitmap, float const transform[9])
 {
   Primitive p;
   p.cmd               = PrimitiveCmd::DrawTransformedBitmap;
@@ -613,7 +613,7 @@ void Canvas::drawTransformedBitmap(Bitmap const * bitmap, float const transform[
   matrix(2, 1) = 0.0f;
   matrix(2, 2) = 1.0f;
   dspm::Mat invMatrix = matrix.inverse();
-  p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(bitmap, transform, invMatrix.data);
+  p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(X, Y, bitmap, transform, invMatrix.data);
   m_displayController->addPrimitive(p);
 }
 

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -602,7 +602,18 @@ void Canvas::drawTransformedBitmap(Bitmap const * bitmap, float const transform[
 {
   Primitive p;
   p.cmd               = PrimitiveCmd::DrawTransformedBitmap;
-  p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(bitmap, transform);
+  auto matrix = dspm::Mat(3, 3);
+  matrix(0, 0) = transform[0];
+  matrix(0, 1) = transform[1];
+  matrix(0, 2) = transform[2];
+  matrix(1, 0) = transform[3];
+  matrix(1, 1) = transform[4];
+  matrix(1, 2) = transform[5];
+  matrix(2, 0) = 0.0f;
+  matrix(2, 1) = 0.0f;
+  matrix(2, 2) = 1.0f;
+  dspm::Mat invMatrix = matrix.inverse();
+  p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(bitmap, transform, invMatrix.data);
   m_displayController->addPrimitive(p);
 }
 

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -598,6 +598,15 @@ void Canvas::copyToBitmap(int srcX, int srcY, Bitmap const * bitmap)
 }
 
 
+void Canvas::drawTransformedBitmap(Bitmap const * bitmap, float const transform[9])
+{
+  Primitive p;
+  p.cmd               = PrimitiveCmd::DrawTransformedBitmap;
+  p.bitmapTransformedDrawingInfo = BitmapTransformedDrawingInfo(bitmap, transform);
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::swapBuffers()
 {
   Primitive p;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -822,7 +822,7 @@ public:
    * @param bitmap Pointer to bitmap structure.
    * @param transform 3x3 matrix to apply to the bitmap.
    */
-  void drawTransformedBitmap(Bitmap const * bitmap, float const transform[9]);
+  void drawTransformedBitmap(int X, int Y, Bitmap const * bitmap, float const transform[9]);
 
   /**
    * @brief Draws a sequence of lines.

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -813,6 +813,18 @@ public:
   void copyToBitmap(int X, int Y, Bitmap const * bitmap);
 
   /**
+   * @brief Draws a bitmap at specified position using a transform.
+   *
+   * Bitmap will be plotted using the specified 3x3 matrix transform.
+   * Note that the transform matrix must include a translation to the desired position.
+   * On-screen position is drawn relative to currently defined origin.
+   *
+   * @param bitmap Pointer to bitmap structure.
+   * @param transform 3x3 matrix to apply to the bitmap.
+   */
+  void drawTransformedBitmap(Bitmap const * bitmap, float const transform[9]);
+
+  /**
    * @brief Draws a sequence of lines.
    *
    * @param points A pointer to an array of Point objects. Points array is copied to a temporary buffer.

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -821,8 +821,9 @@ public:
    *
    * @param bitmap Pointer to bitmap structure.
    * @param transform 3x3 matrix to apply to the bitmap.
+   * @param invTransform inverse of transform, used to work out source pixels in bitmap
    */
-  void drawTransformedBitmap(int X, int Y, Bitmap const * bitmap, float const transform[9]);
+  void drawTransformedBitmap(int X, int Y, Bitmap const * bitmap, float const transform[9], float const * invTransform = nullptr);
 
   /**
    * @brief Draws a sequence of lines.

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -647,12 +647,12 @@ void VGA16Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * save
 }
 
 
-void VGA16Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA16Controller::rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
   auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
-  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_Mask(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA16_GETPIXELINROW
                                           [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
@@ -660,7 +660,7 @@ void VGA16Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rec
 }
 
 
-void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -668,7 +668,7 @@ void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY,
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                               [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                               // VGA16_GETPIXELINROW
                                               [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
@@ -676,7 +676,7 @@ void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY,
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA16_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
@@ -684,7 +684,7 @@ void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY,
 }
 
 
-void VGA16Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA16Controller::rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -692,7 +692,7 @@ void VGA16Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY,
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                             [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                             // VGA16_GETPIXELINROW,                                                                     // rawGetPixelInRow
                                             [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
@@ -700,7 +700,7 @@ void VGA16Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY,
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA16_GETPIXELINROW,                                                                      // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -647,6 +647,19 @@ void VGA16Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * save
 }
 
 
+void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA16_GETPIXELINROW
+                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void IRAM_ATTR VGA16Controller::ISRHandler(void * arg)
 {
   #if FABGLIB_VGAXCONTROLLER_PERFORMANCE_CHECK

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -652,6 +652,17 @@ void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY,
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
 
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                              [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                              // VGA16_GETPIXELINROW
+                                              [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
+                                             );
+    return;
+  }
+
   genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA16_GETPIXELINROW

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -647,7 +647,7 @@ void VGA16Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * save
 }
 
 
-void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+void VGA16Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -179,6 +179,9 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -179,7 +179,7 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -179,13 +179,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -179,7 +179,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -630,7 +630,7 @@ void VGA2Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
-void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -635,6 +635,17 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
 
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                              [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                              // VGA2_GETPIXELINROW
+                                              [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
+                                             );
+    return;
+  }
+
   genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA2_GETPIXELINROW

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -638,7 +638,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA2_GETPIXELINROW
-                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, src); }  // rawSetPixelInRow
+                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
                                          );
 }
 

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -630,12 +630,12 @@ void VGA2Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
-void VGA2Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA2Controller::rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
   auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
-  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_Mask(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA2_GETPIXELINROW
                                           [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
@@ -643,7 +643,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect
 }
 
 
-void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -651,7 +651,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                               [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                               // VGA2_GETPIXELINROW
                                               [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
@@ -659,7 +659,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA2_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
@@ -667,7 +667,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
 }
 
 
-void VGA2Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA2Controller::rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -675,7 +675,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                             [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                             // VGA2_GETPIXELINROW,                                                                     // rawGetPixelInRow
                                             [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
@@ -683,7 +683,7 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA2_GETPIXELINROW,                                                                      // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -630,6 +630,19 @@ void VGA2Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
+void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA2_GETPIXELINROW
+                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, src); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void IRAM_ATTR VGA2Controller::ISRHandler(void * arg)
 {
   #if FABGLIB_VGAXCONTROLLER_PERFORMANCE_CHECK

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -630,6 +630,19 @@ void VGA2Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
+void VGA2Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
+  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA2_GETPIXELINROW
+                                          [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
@@ -650,6 +663,30 @@ void VGA2Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA2_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
+                                         );
+}
+
+
+void VGA2Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                            [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                            // VGA2_GETPIXELINROW,                                                                     // rawGetPixelInRow
+                                            [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                          );
+    return;
+  }
+
+  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA2_GETPIXELINROW,                                                                      // rawGetPixelInRow
+                                          [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
                                          );
 }
 

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -181,7 +181,7 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -181,6 +181,9 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -181,7 +181,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -181,13 +181,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -659,6 +659,19 @@ void VGA4Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
+void VGA4Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
+  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA4_GETPIXELINROW
+                                          [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
@@ -679,6 +692,30 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA4_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
+                                         );
+}
+
+
+void VGA4Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                            [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                            // VGA4_GETPIXELINROW,                                                                     // rawGetPixelInRow
+                                            [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                          );
+    return;
+  }
+
+  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA4_GETPIXELINROW,                                                                      // rawGetPixelInRow
+                                          [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
                                          );
 }
 

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -659,6 +659,19 @@ void VGA4Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
+void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA4_GETPIXELINROW
+                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void IRAM_ATTR VGA4Controller::ISRHandler(void * arg)
 {
   #if FABGLIB_VGAXCONTROLLER_PERFORMANCE_CHECK

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -659,7 +659,7 @@ void VGA4Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
-void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -664,6 +664,17 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
 
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                              [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                              // VGA4_GETPIXELINROW
+                                              [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
+                                             );
+    return;
+  }
+
   genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA4_GETPIXELINROW

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -659,12 +659,12 @@ void VGA4Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
-void VGA4Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA4Controller::rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
   auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
-  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_Mask(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA4_GETPIXELINROW
                                           [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
@@ -672,7 +672,7 @@ void VGA4Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect
 }
 
 
-void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -680,7 +680,7 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                               [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                               // VGA4_GETPIXELINROW
                                               [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
@@ -688,7 +688,7 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA4_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
@@ -696,7 +696,7 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
 }
 
 
-void VGA4Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA4Controller::rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -704,7 +704,7 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                             [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                             // VGA4_GETPIXELINROW,                                                                     // rawGetPixelInRow
                                             [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
@@ -712,7 +712,7 @@ void VGA4Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA4_GETPIXELINROW,                                                                      // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -178,7 +178,7 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -178,13 +178,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -178,6 +178,9 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -178,7 +178,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -607,6 +607,19 @@ void VGA8Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
+void VGA8Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
+  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA8_GETPIXELINROW
+                                          [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
@@ -627,6 +640,30 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA8_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
+                                         );
+}
+
+
+void VGA8Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                            [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                            // VGA8_GETPIXELINROW,                                                                     // rawGetPixelInRow
+                                            [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                          );
+    return;
+  }
+
+  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA8_GETPIXELINROW,                                                                      // rawGetPixelInRow
+                                          [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow
                                          );
 }
 

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -607,6 +607,19 @@ void VGA8Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
+void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // VGA8_GETPIXELINROW
+                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void VGA8Controller::directSetPixel(int x, int y, int value)
 {
   VGA8_SETPIXEL(x, y, value);

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -607,7 +607,7 @@ void VGA8Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
-void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -607,12 +607,12 @@ void VGA8Controller::rawCopyToBitmap(int srcX, int srcY, int width, void * saveB
 }
 
 
-void VGA8Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA8Controller::rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
   auto foregroundColorIndex = RGB888toPaletteIndex(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
-  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_Mask(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA8_GETPIXELINROW
                                           [&] (uint8_t * row, int x) { setRowPixel(row, x, foregroundColorIndex); }  // rawSetPixelInRow
@@ -620,7 +620,7 @@ void VGA8Controller::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect
 }
 
 
-void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -628,7 +628,7 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                               [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                               // VGA8_GETPIXELINROW
                                               [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
@@ -636,7 +636,7 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA8_GETPIXELINROW
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, RGB2222toPaletteIndex(src)); }  // rawSetPixelInRow
@@ -644,7 +644,7 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
 }
 
 
-void VGA8Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void VGA8Controller::rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -652,7 +652,7 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = RGB888toPaletteIndex(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                             [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                             // VGA8_GETPIXELINROW,                                                                     // rawGetPixelInRow
                                             [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
@@ -660,7 +660,7 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA8_GETPIXELINROW,                                                                      // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, RGB8888toPaletteIndex(src)); }   // rawSetPixelInRow

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -612,6 +612,17 @@ void VGA8Controller::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, 
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
 
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = RGB888toPaletteIndex(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                              [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                              // VGA8_GETPIXELINROW
+                                              [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
+                                             );
+    return;
+  }
+
   genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // VGA8_GETPIXELINROW

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -182,6 +182,9 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t colorIndex);

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -182,7 +182,7 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -182,7 +182,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -182,13 +182,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -740,4 +740,17 @@ void IRAM_ATTR VGAController::rawCopyToBitmap(int srcX, int srcY, int width, voi
 }
 
 
+void VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
+                                          [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, src); }  // rawSetPixelInRow
+                                         );
+}
+
+
 } // end of namespace

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -740,7 +740,7 @@ void IRAM_ATTR VGAController::rawCopyToBitmap(int srcX, int srcY, int width, voi
 }
 
 
-void VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix)
+void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -745,6 +745,17 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int 
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
 
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = preparePixel(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+                                            [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                            // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
+                                            [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
+                                          );
+    return;
+  }
+
   genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -740,6 +740,20 @@ void IRAM_ATTR VGAController::rawCopyToBitmap(int srcX, int srcY, int width, voi
 }
 
 
+void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+  auto getPixel = getPixelLambda(paintMode);
+  auto pattern = getPixel(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
+  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
+                                          [&] (uint8_t * row, int x) { setRowPixel(row, x, pattern); }  // rawSetPixelInRow
+                                         );
+}
+
+
 void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
@@ -760,6 +774,30 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int 
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, src); }  // rawSetPixelInRow
+                                         );
+}
+
+
+void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+{
+  auto paintMode = paintState().paintOptions.mode;
+  auto setRowPixel = setRowPixelLambda(paintMode);
+
+  if (paintState().paintOptions.swapFGBG) {
+    // used for bitmap plots to indicate drawing with BG color instead of bitmap color
+    auto bg = preparePixel(paintState().penColor);
+    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                            [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                            // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
+                                            [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
+                                          );
+    return;
+  }
+
+  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+                                          [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
+                                          // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
+                                          [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, m_HVSync | (src.R >> 6) | (src.G >> 6 << 2) | (src.B >> 6 << 4)); }   // rawSetPixelInRow
                                          );
 }
 

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -740,13 +740,13 @@ void IRAM_ATTR VGAController::rawCopyToBitmap(int srcX, int srcY, int width, voi
 }
 
 
-void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
   auto getPixel = getPixelLambda(paintMode);
   auto pattern = getPixel(paintState().paintOptions.swapFGBG ? paintState().penColor : bitmap->foregroundColor);
-  genericRawDrawTransformedBitmap_Mask(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_Mask(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
                                           [&] (uint8_t * row, int x) { setRowPixel(row, x, pattern); }  // rawSetPixelInRow
@@ -754,7 +754,7 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_Mask(int originX, int orig
 }
 
 
-void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -762,7 +762,7 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = preparePixel(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                             [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                             // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
                                             [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, bg); }  // rawSetPixelInRow
@@ -770,7 +770,7 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA2222(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA2222(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, uint8_t src) { setRowPixel(row, x, src); }  // rawSetPixelInRow
@@ -778,7 +778,7 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA2222(int originX, int 
 }
 
 
-void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
+void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix)
 {
   auto paintMode = paintState().paintOptions.mode;
   auto setRowPixel = setRowPixelLambda(paintMode);
@@ -786,7 +786,7 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA8888(int originX, int 
   if (paintState().paintOptions.swapFGBG) {
     // used for bitmap plots to indicate drawing with BG color instead of bitmap color
     auto bg = preparePixel(paintState().penColor);
-    genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+    genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                             [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                             // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
                                             [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, bg); }           // rawSetPixelInRow
@@ -794,7 +794,7 @@ void IRAM_ATTR VGAController::rawDrawBitmapWithMatrix_RGBA8888(int originX, int 
     return;
   }
 
-  genericRawDrawTransformedBitmap_RGBA8888(originX, originY, drawingRect, bitmap, invMatrix,
+  genericRawDrawTransformedBitmap_RGBA8888(destX, destY, drawingRect, bitmap, invMatrix,
                                           [&] (int y)                { return (uint8_t*) m_viewPort[y]; },  // rawGetRow
                                           // [&] (uint8_t * row, int x) { return VGA_PIXELINROW(row, x); },    // rawGetPixelInRow
                                           [&] (uint8_t * row, int x, RGBA8888 const & src) { setRowPixel(row, x, m_HVSync | (src.R >> 6) | (src.G >> 6 << 2) | (src.B >> 6 << 4)); }   // rawSetPixelInRow

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -259,13 +259,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_Mask(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA8888(int destX, int destY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -259,6 +259,9 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);
 
   void rawFillRow(int y, int x1, int x2, uint8_t pattern);

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -259,7 +259,13 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
   void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
+
+  // abstract method of BitmappedDisplayController
+  void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -259,7 +259,7 @@ private:
   void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount);
 
   // abstract method of BitmappedDisplayController
-  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix);
+  void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix);
 
   // abstract method of BitmappedDisplayController
   void fillRow(int y, int x1, int x2, RGB888 color);

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -1449,17 +1449,17 @@ void IRAM_ATTR BitmappedDisplayController::drawBitmapWithTransform(BitmapTransfo
     //   rawDrawBitmapWithMatrix_Native(x, y, drawingRect, drawingInfo.bitmap, drawingInfo.transformInverse);
     //   break;
 
-    // case PixelFormat::Mask:
-    //   rawDrawBitmapWithMatrix_Mask(x, y, drawingRect, drawingInfo.bitmap, drawingInfo.transformInverse);
-    //   break;
+    case PixelFormat::Mask:
+      rawDrawBitmapWithMatrix_Mask(x, y, drawingRect, drawingInfo.bitmap, drawingInfo.transformInverse);
+      break;
 
     case PixelFormat::RGBA2222:
       rawDrawBitmapWithMatrix_RGBA2222(x, y, drawingRect, drawingInfo.bitmap, drawingInfo.transformInverse);
       break;
 
-    // case PixelFormat::RGBA8888:
-    //   rawDrawBitmapWithMatrix_RGBA8888(x, y, drawingRect, drawingInfo.bitmap, drawingInfo.transformInverse);
-    //   break;
+    case PixelFormat::RGBA8888:
+      rawDrawBitmapWithMatrix_RGBA8888(x, y, drawingRect, drawingInfo.bitmap, drawingInfo.transformInverse);
+      break;
 
   }
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -1389,30 +1389,30 @@ void IRAM_ATTR BitmappedDisplayController::drawBitmapWithTransform(BitmapTransfo
   dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
-  maxX = imax(maxX, (int)(transformed[0] + 0.5f));
-  maxY = imax(maxY, (int)(transformed[1] + 0.5f));
+  maxX = imax(maxX, (int)transformed[0]);
+  maxY = imax(maxY, (int)transformed[1]);
 
   pos[0] = (float)originalBox.X2;
   dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
-  maxX = imax(maxX, (int)(transformed[0] + 0.5f));
-  maxY = imax(maxY, (int)(transformed[1] + 0.5f));
+  maxX = imax(maxX, (int)transformed[0]);
+  maxY = imax(maxY, (int)transformed[1]);
 
   pos[0] = (float)originalBox.X1;
   pos[1] = (float)originalBox.Y2;
   dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
-  maxX = imax(maxX, (int)(transformed[0] + 0.5f));
-  maxY = imax(maxY, (int)(transformed[1] + 0.5f));
+  maxX = imax(maxX, (int)transformed[0]);
+  maxY = imax(maxY, (int)transformed[1]);
 
   pos[0] = (float)originalBox.X2;
   dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
-  maxX = imax(maxX, (int)(transformed[0] + 0.5f));
-  maxY = imax(maxY, (int)(transformed[1] + 0.5f));
+  maxX = imax(maxX, (int)transformed[0]);
+  maxY = imax(maxY, (int)transformed[1]);
 
   Rect transformedBox = Rect(minX, minY, maxX, maxY);
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -1386,14 +1386,14 @@ void IRAM_ATTR BitmappedDisplayController::drawBitmapWithTransform(BitmapTransfo
   int maxY = INT_MIN;
   float pos[3] = { (float)originalBox.X1, (float)originalBox.Y1, 1.0f };
   float transformed[3];
-  dspm_mult_f32(transformMatrix, pos, transformed, 3, 3, 1);
+  dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
   maxX = imax(maxX, (int)(transformed[0] + 0.5f));
   maxY = imax(maxY, (int)(transformed[1] + 0.5f));
 
   pos[0] = (float)originalBox.X2;
-  dspm_mult_f32(transformMatrix, pos, transformed, 3, 3, 1);
+  dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
   maxX = imax(maxX, (int)(transformed[0] + 0.5f));
@@ -1401,14 +1401,14 @@ void IRAM_ATTR BitmappedDisplayController::drawBitmapWithTransform(BitmapTransfo
 
   pos[0] = (float)originalBox.X1;
   pos[1] = (float)originalBox.Y2;
-  dspm_mult_f32(transformMatrix, pos, transformed, 3, 3, 1);
+  dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
   maxX = imax(maxX, (int)(transformed[0] + 0.5f));
   maxY = imax(maxY, (int)(transformed[1] + 0.5f));
 
   pos[0] = (float)originalBox.X2;
-  dspm_mult_f32(transformMatrix, pos, transformed, 3, 3, 1);
+  dspm_mult_3x3x1_f32(transformMatrix, pos, transformed);
   minX = imin(minX, (int)transformed[0]);
   minY = imin(minY, (int)transformed[1]);
   maxX = imax(maxX, (int)(transformed[0] + 0.5f));

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -1371,8 +1371,8 @@ void IRAM_ATTR BitmappedDisplayController::absCopyToBitmap(int srcX, int srcY, B
 void IRAM_ATTR BitmappedDisplayController::drawBitmapWithTransform(BitmapTransformedDrawingInfo const & drawingInfo, Rect & updateRect)
 {
   // work out corners of the bitmap by taking the corners of the bitmap and transforming them by the matrix
-  int x = paintState().origin.X;
-  int y = paintState().origin.Y;
+  int x = paintState().origin.X + drawingInfo.X;
+  int y = paintState().origin.Y + drawingInfo.Y;
   int width = drawingInfo.bitmap->width;
   int height = drawingInfo.bitmap->height;
 

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -2360,22 +2360,23 @@ protected:
     float maxY = drawingRect.Y2;
     auto data = bitmap->data;
     const int rowlen = (bitmap->width + 7) / 8;
+    const float widthF = (float)bitmap->width;
+    const float heightF = (float)bitmap->height;
  
-    for (float y = drawingRect.Y1; y <= maxY; y++) {
-      for (float x = drawingRect.X1; x <= maxX; x++) {
+    for (float y = drawingRect.Y1; y < maxY; y++) {
+      for (float x = drawingRect.X1; x < maxX; x++) {
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
         dspm_mult_3x3x1_f32(invMatrix, pos, srcPos);
-        
-        int srcXint = (int) (srcPos[0] - 0.5f);
-        int srcYint = (int) (srcPos[1] - 0.5f);
-        if (srcXint >= 0 && srcXint < bitmap->width && srcYint >= 0 && srcYint < bitmap->height) {
 
-          auto srcRow = data + srcYint * rowlen;
-          if ((srcRow[srcXint >> 3] << (srcXint & 7)) & 0x80)
-            rawSetPixelInRow(rawGetRow((int)y + destY), (int)x + destX);
-        }
+        if (srcPos[0] < 0.0f || srcPos[0] >= widthF || srcPos[1] < 0 || srcPos[1] >= heightF)
+          continue;
+
+        auto srcRow = data + (int)srcPos[1] * rowlen;
+        int srcXint = (int)srcPos[0];
+        if ((srcRow[srcXint >> 3] << (srcXint & 7)) & 0x80)
+          rawSetPixelInRow(rawGetRow((int)y + destY), (int)x + destX);
       }
     }
   }
@@ -2396,21 +2397,22 @@ protected:
     float maxY = drawingRect.Y2;
     auto data = bitmap->data;
     const int width = bitmap->width;
+    const float widthF = (float)width;
+    const float heightF = (float)bitmap->height;
  
-    for (float y = drawingRect.Y1; y <= maxY; y++) {
-      for (float x = drawingRect.X1; x <= maxX; x++) {
+    for (float y = drawingRect.Y1; y < maxY; y++) {
+      for (float x = drawingRect.X1; x < maxX; x++) {
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
         dspm_mult_3x3x1_f32(invMatrix, pos, srcPos);
-        
-        int srcXint = (int) (srcPos[0] - 0.5f);
-        int srcYint = (int) (srcPos[1] - 0.5f);
-        if (srcXint >= 0 && srcXint < bitmap->width && srcYint >= 0 && srcYint < bitmap->height) {
-          auto src = data + srcYint * width + srcXint;
-          if (*src & 0xc0)  // alpha > 0 ?
-            rawSetPixelInRow(rawGetRow((int)y + destY), (int)x + destX, *src);
-        }
+
+        if (srcPos[0] < 0.0f || srcPos[0] >= widthF || srcPos[1] < 0 || srcPos[1] >= heightF)
+          continue;
+
+        auto src = data + (int)srcPos[1] * width + (int)srcPos[0];
+        if (*src & 0xc0)  // alpha > 0 ?
+          rawSetPixelInRow(rawGetRow((int)y + destY), (int)x + destX, *src);
       }
     }
   }
@@ -2431,21 +2433,22 @@ protected:
     float maxY = drawingRect.Y2;
     auto data = (RGBA8888 const *) bitmap->data;
     const int width = bitmap->width;
+    const float widthF = (float)width;
+    const float heightF = (float)bitmap->height;
  
-    for (float y = drawingRect.Y1; y <= maxY; y++) {
-      for (float x = drawingRect.X1; x <= maxX; x++) {
+    for (float y = drawingRect.Y1; y < maxY; y++) {
+      for (float x = drawingRect.X1; x < maxX; x++) {
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
         dspm_mult_3x3x1_f32(invMatrix, pos, srcPos);
-        
-        int srcXint = (int) (srcPos[0] - 0.5f);
-        int srcYint = (int) (srcPos[1] - 0.5f);
-        if (srcXint >= 0 && srcXint < bitmap->width && srcYint >= 0 && srcYint < bitmap->height) {
-          auto src = data + srcYint * width + srcXint;
-          if (src->A)
-            rawSetPixelInRow(rawGetRow((int)y + destY),  (int)x + destX, *src);
-        }
+
+        if (srcPos[0] < 0.0f || srcPos[0] >= widthF || srcPos[1] < 0 || srcPos[1] >= heightF)
+          continue;
+
+        auto src = data + (int)srcPos[1] * width + (int)srcPos[0];
+        if (src->A)
+          rawSetPixelInRow(rawGetRow((int)y + destY),  (int)x + destX, *src);
       }
     }
   }

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -2376,25 +2376,16 @@ protected:
     // drawingRect should be all on-screen, pre-clipped, but moved to -originX, -originY
     float pos[3] = {0.0f, 0.0f, 1.0f};
     float srcPos[3] = {0.0f, 0.0f, 1.0f};
-  	// auto posMatrix = dspm::Mat((float *)&pos, 3, 1);
-  	// auto posMatrix = dspm::Mat(3, 1);
-    // posMatrix(2, 0) = 1.0f;
     float maxX = drawingRect.X2;
     float maxY = drawingRect.Y2;
-    // float maxY = 122.0f;
  
     for (float y = drawingRect.Y1; y <= maxY; y++) {
       for (float x = drawingRect.X1; x <= maxX; x++) {
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
-        // posMatrix(0, 0) = x;
-        // posMatrix(1, 0) = y;
-        // auto transformed = invMatrix * posMatrix;
         dspm_mult_f32(invMatrix, pos, srcPos, 3, 3, 1);
         
-        // int srcXint = (int) transformed(0, 0);
-        // int srcYint = (int) transformed(1, 0);
         int srcXint = (int) (srcPos[0] - 0.5f);
         int srcYint = (int) (srcPos[1] - 0.5f);
         if (srcXint >= 0 && srcXint < bitmap->width && srcYint >= 0 && srcYint < bitmap->height) {

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -2364,7 +2364,7 @@ protected:
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
-        dspm_mult_f32(invMatrix, pos, srcPos, 3, 3, 1);
+        dspm_mult_3x3x1_f32(invMatrix, pos, srcPos);
         
         int srcXint = (int) (srcPos[0] - 0.5f);
         int srcYint = (int) (srcPos[1] - 0.5f);
@@ -2400,7 +2400,7 @@ protected:
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
-        dspm_mult_f32(invMatrix, pos, srcPos, 3, 3, 1);
+        dspm_mult_3x3x1_f32(invMatrix, pos, srcPos);
         
         int srcXint = (int) (srcPos[0] - 0.5f);
         int srcYint = (int) (srcPos[1] - 0.5f);
@@ -2435,7 +2435,7 @@ protected:
         // calculate the source pixel
         pos[0] = x;
         pos[1] = y;
-        dspm_mult_f32(invMatrix, pos, srcPos, 3, 3, 1);
+        dspm_mult_3x3x1_f32(invMatrix, pos, srcPos);
         
         int srcXint = (int) (srcPos[0] - 0.5f);
         int srcYint = (int) (srcPos[1] - 0.5f);

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -537,38 +537,16 @@ struct BitmapDrawingInfo {
   BitmapDrawingInfo(int X_, int Y_, Bitmap const * bitmap_) : X(X_), Y(Y_), bitmap(bitmap_) { }
 } __attribute__ ((packed));
 
+
 struct BitmapTransformedDrawingInfo {
   Bitmap const * bitmap;
-  // float transformA;
-  // float transformB;
-  // float transformC;
-  // float transformD;
-  // float transformE;
-  // float transformF;
-  // float transformMatrix[9];
-  float const * transformMatrix;
-  float const * transformInverse;
-  bool          freeMatrix;
+  float const *  transformMatrix;
+  float const *  transformInverse;
+  bool           freeMatrix;
 
   BitmapTransformedDrawingInfo(Bitmap const * bitmap_, float const * transformMatrix_, float const * transformInverse_) : 
-  bitmap(bitmap_), transformMatrix(transformMatrix_), transformInverse(transformInverse_), freeMatrix(false) {  }
-
-  // // BitmapTransformedDrawingInfo(Bitmap const * bitmap_, float const transformMatrix_[9]) : bitmap(bitmap_) {
-  // BitmapTransformedDrawingInfo(Bitmap const * bitmap_, float const * transformMatrix_) : bitmap(bitmap_) {
-  //   // transformA = transformMatrix_[0];
-  //   // transformB = transformMatrix_[1];
-  //   // transformC = transformMatrix_[2];
-  //   // transformD = transformMatrix_[3];
-  //   // transformE = transformMatrix_[4];
-  //   // transformF = transformMatrix_[5];
-  //   transformMatrix = transformMatrix_;
-
-  //   // for (int i = 0; i < 9; i++) {
-  //   //   transformMatrix[i] = transformMatrix_[i];
-  //   // }
-  //   freeMatrix = false;
-  // }
-} __attribute__ ((packed));;
+    bitmap(bitmap_), transformMatrix(transformMatrix_), transformInverse(transformInverse_), freeMatrix(false) { }
+} __attribute__ ((packed));
 
 
 /** \ingroup Enumerations
@@ -1072,13 +1050,13 @@ protected:
 
   virtual void rawCopyToBitmap(int srcX, int srcY, int width, void * saveBuffer, int X1, int Y1, int XCount, int YCount) = 0;
 
-  // virtual void rawDrawBitmapWithMatrix_Native(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix) = 0;
+  // virtual void rawDrawBitmapWithMatrix_Native(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix) = 0;
 
-  // virtual void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix) = 0;
+  // virtual void rawDrawBitmapWithMatrix_Mask(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix) = 0;
   
   virtual void rawDrawBitmapWithMatrix_RGBA2222(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix) = 0;
   
-  // virtual void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, dspm::Mat & invMatrix) = 0;
+  // virtual void rawDrawBitmapWithMatrix_RGBA8888(int originX, int originY, Rect & drawingRect, Bitmap const * bitmap, const float * invMatrix) = 0;
 
   //// implemented methods
 


### PR DESCRIPTION
adds functionality to draw bitmaps with an affine transform

this is implemented for all screen depths, and all bitmap formats except for "native" format.  for now "native" has been omitted because currently setting a transform for a sprite is not supported, and it is essentially only for restoring saved sprite backgrounds that "native" format is used