### PR TITLE
add a noOp function to canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.vscode
+.DS_Store

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -662,4 +662,12 @@ RGB888 Canvas::getPixel(int X, int Y)
 }
 
 
+void Canvas::noOp()
+{
+  Primitive p;
+  p.cmd = PrimitiveCmd::Flush;
+  m_displayController->addPrimitive(p);
+}
+
+
 } // end of namespace

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -866,6 +866,13 @@ public:
    */
   RGB888 getPixel(int X, int Y);
 
+  /**
+   * @brief Add a no-op to the canvas queue
+   * 
+   * This is useful to force a waitCompletion() to wait for the next VSync
+   */
+  void noOp();
+
 private:
 
   BitmappedDisplayController * m_displayController;


### PR DESCRIPTION
when used in conjunction with `canvas->waitCompletion(true)` this can ensure that the call definitely waits for VSYNC, as a call to wait when the drawing primitives queue is empty will return immediately