### PR TITLE
Hw and sw sprites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode
 .DS_Store
+/build

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -720,8 +720,10 @@ void IRAM_ATTR VGA16Controller::ISRHandler(void * arg)
 
     auto const desc = (lldesc_t*) I2S1.out_eof_des_addr;
 
-    if (desc == s_frameResetDesc)
+    if (desc == s_frameResetDesc) {
       s_scanLine = 0;
+      s_scanRow = 0;
+    }
 
     auto const width  = ctrl->m_viewPortWidth;
     auto const height = ctrl->m_viewPortHeight;
@@ -736,6 +738,7 @@ void IRAM_ATTR VGA16Controller::ISRHandler(void * arg)
 
       auto src  = (uint8_t const *) s_viewPortVisible[scanLine];
       auto dest = (uint16_t*) lines[lineIndex];
+      uint8_t* decpix = (uint8_t*) dest;
 
       // optimization warn: horizontal resolution must be a multiple of 16!
       for (int col = 0; col < width; col += 16) {
@@ -774,8 +777,10 @@ void IRAM_ATTR VGA16Controller::ISRHandler(void * arg)
 
       }
 
+      ctrl->decorateScanLinePixels(decpix);
       ++lineIndex;
       ++scanLine;
+      ++s_scanRow;
     }
 
     s_scanLine += VGA16_LinesCount / 2;

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -703,8 +703,10 @@ void IRAM_ATTR VGA2Controller::ISRHandler(void * arg)
 
     auto const desc = (lldesc_t*) I2S1.out_eof_des_addr;
 
-    if (desc == s_frameResetDesc)
+    if (desc == s_frameResetDesc) {
       s_scanLine = 0;
+      s_scanRow = 0;
+    }
 
     auto const width  = ctrl->m_viewPortWidth;
     auto const height = ctrl->m_viewPortHeight;
@@ -719,6 +721,7 @@ void IRAM_ATTR VGA2Controller::ISRHandler(void * arg)
 
       auto src  = (uint8_t const *) s_viewPortVisible[scanLine];
       auto dest = (uint64_t*) lines[lineIndex];
+      uint8_t* decpix = (uint8_t*) dest;
 
       // optimization warn: horizontal resolution must be a multiple of 16!
       for (int col = 0; col < width; col += 16) {
@@ -739,8 +742,11 @@ void IRAM_ATTR VGA2Controller::ISRHandler(void * arg)
         
       }
 
+      ctrl->decorateScanLinePixels(decpix);
+
       ++lineIndex;
       ++scanLine;
+      ++s_scanRow;
     }
 
     s_scanLine += VGA2_LinesCount / 2;

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -732,8 +732,10 @@ void IRAM_ATTR VGA4Controller::ISRHandler(void * arg)
 
     auto const desc = (lldesc_t*) I2S1.out_eof_des_addr;
 
-    if (desc == s_frameResetDesc)
+    if (desc == s_frameResetDesc) {
       s_scanLine = 0;
+      s_scanRow = 0;
+    }
 
     auto const width  = ctrl->m_viewPortWidth;
     auto const height = ctrl->m_viewPortHeight;
@@ -748,6 +750,7 @@ void IRAM_ATTR VGA4Controller::ISRHandler(void * arg)
 
       auto src  = (uint8_t const *) s_viewPortVisible[scanLine];
       auto dest = (uint32_t*) lines[lineIndex];
+      uint8_t* decpix = (uint8_t*) dest;
 
       // optimization warn: horizontal resolution must be a multiple of 16!
       for (int col = 0; col < width; col += 16) {
@@ -773,8 +776,10 @@ void IRAM_ATTR VGA4Controller::ISRHandler(void * arg)
         src += 4;
       }
 
+      ctrl->decorateScanLinePixels(decpix);
       ++lineIndex;
       ++scanLine;
+      ++s_scanRow;
     }
 
     s_scanLine += VGA4_LinesCount / 2;

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -686,8 +686,10 @@ void IRAM_ATTR VGA8Controller::ISRHandler(void * arg)
 
     auto const desc = (lldesc_t*) I2S1.out_eof_des_addr;
 
-    if (desc == s_frameResetDesc)
+    if (desc == s_frameResetDesc) {
       s_scanLine = 0;
+      s_scanRow = 0;
+    }
 
     auto const width  = ctrl->m_viewPortWidth;
     auto const height = ctrl->m_viewPortHeight;
@@ -702,6 +704,7 @@ void IRAM_ATTR VGA8Controller::ISRHandler(void * arg)
 
       auto src  = (uint8_t const *) s_viewPortVisible[scanLine];
       auto dest = (uint16_t*) lines[lineIndex];
+      uint8_t* decpix = (uint8_t*) dest;
 
       // optimization warn: horizontal resolution must be a multiple of 16!
       for (int col = 0; col < width; col += 16) {
@@ -738,8 +741,10 @@ void IRAM_ATTR VGA8Controller::ISRHandler(void * arg)
 
       }
 
+      ctrl->decorateScanLinePixels(decpix);
       ++lineIndex;
       ++scanLine;
+      ++s_scanRow;
     }
 
     s_scanLine += VGA8_LinesCount / 2;

--- a/src/dispdrivers/vgabasecontroller.cpp
+++ b/src/dispdrivers/vgabasecontroller.cpp
@@ -53,6 +53,13 @@ namespace fabgl {
   volatile uint64_t s_vgapalctrlcycles = 0;
 #endif
 
+volatile uint8_t * * VGABaseController::s_viewPort;
+volatile uint8_t * * VGABaseController::s_viewPortVisible;
+lldesc_t volatile *  VGABaseController::s_frameResetDesc;
+volatile int         VGABaseController::s_scanLine;
+volatile int         VGABaseController::s_scanRow;
+volatile int         VGABaseController::s_scanWidth;
+volatile int         VGABaseController::s_viewPortHeight;
 
 
 VGABaseController::VGABaseController()
@@ -391,6 +398,8 @@ void VGABaseController::setResolution(VGATimings const& timings, int viewPortWid
   m_viewPortRow = m_viewPortRow & ~3;
 
   m_rawFrameHeight = m_timings.VVisibleArea + m_timings.VFrontPorch + m_timings.VSyncPulse + m_timings.VBackPorch;
+  s_scanWidth = m_viewPortWidth;
+  s_viewPortHeight = m_viewPortHeight;
 
   // allocate DMA descriptors
   setDMABuffersCount(calcRequiredDMABuffersCount(m_viewPortHeight));
@@ -754,6 +763,10 @@ void IRAM_ATTR VGABaseController::swapBuffers()
 }
 
 
+// Chance to overwrite a scan line in the output DMA buffer.
+void IRAM_ATTR VGABaseController::decorateScanLinePixels(uint8_t * pixels) {
+  drawSpriteScanLine(pixels, s_scanRow, s_scanWidth, s_viewPortHeight);
+}
 
 
 } // end of namespace

--- a/src/dispdrivers/vgabasecontroller.h
+++ b/src/dispdrivers/vgabasecontroller.h
@@ -366,6 +366,7 @@ protected:
   static volatile int         s_scanWidth;
   static volatile int         s_viewPortHeight;
 
+  int                         m_linesCount;     // viewport height must be divisible by m_linesCount
 
 private:
 

--- a/src/dispdrivers/vgabasecontroller.h
+++ b/src/dispdrivers/vgabasecontroller.h
@@ -336,6 +336,11 @@ protected:
   // chance to overwrite a scan line in the output DMA buffer
   virtual void decorateScanLinePixels(uint8_t * pixels);
 
+  // Processes primitives upon notification
+  static void primitiveExecTask(void * arg);
+
+  void calculateAvailableCyclesForDrawings();
+
   // when double buffer is enabled the "drawing" view port is always m_viewPort, while the "visible" view port is always m_viewPortVisible
   // when double buffer is not enabled then m_viewPort = m_viewPortVisible
   volatile uint8_t * *   m_viewPort;
@@ -367,6 +372,16 @@ protected:
   static volatile int         s_viewPortHeight;
 
   int                         m_linesCount;     // viewport height must be divisible by m_linesCount
+
+  volatile bool               m_taskProcessingPrimitives;
+  TaskHandle_t                m_primitiveExecTask;
+
+  // Maximum time (in CPU cycles) available for primitives drawing
+  volatile uint32_t           m_primitiveExecTimeoutCycles;
+
+  // true = allowed time to process primitives is limited to the vertical blank. Slow, but avoid flickering
+  // false = allowed time is the half of an entire frame. Fast, but may flick
+  bool                        m_processPrimitivesOnBlank;
 
 private:
 

--- a/src/dispdrivers/vgabasecontroller.h
+++ b/src/dispdrivers/vgabasecontroller.h
@@ -115,7 +115,6 @@ struct VGATimings {
 };
 
 
-
 class VGABaseController : public GenericBitmappedDisplayController {
 
 public:
@@ -289,8 +288,6 @@ public:
 
   uint8_t createBlankRawPixel()                  { return m_HVSync; }
 
-
-
 protected:
 
   static void setupGPIO(gpio_num_t gpio, int bit, gpio_mode_t mode);
@@ -336,6 +333,8 @@ protected:
   // abstract method of BitmappedDisplayController
   virtual void swapBuffers();
 
+  // chance to overwrite a scan line in the output DMA buffer
+  virtual void decorateScanLinePixels(uint8_t * pixels);
 
   // when double buffer is enabled the "drawing" view port is always m_viewPort, while the "visible" view port is always m_viewPortVisible
   // when double buffer is not enabled then m_viewPort = m_viewPortVisible
@@ -355,8 +354,17 @@ protected:
   volatile int16_t       m_viewPortCol;
   volatile int16_t       m_viewPortRow;
 
-  // contains H and V signals for visible line
-  volatile uint8_t       m_HVSync;
+  volatile uint8_t * *        m_lines;
+
+  // optimization: clones of m_viewPort and m_viewPortVisible
+  static volatile uint8_t * * s_viewPort;
+  static volatile uint8_t * * s_viewPortVisible;
+
+  static lldesc_t volatile *  s_frameResetDesc;
+  static volatile int         s_scanLine;
+  static volatile int         s_scanRow;
+  static volatile int         s_scanWidth;
+  static volatile int         s_viewPortHeight;
 
 
 private:

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -65,14 +65,25 @@ VGAController * VGAController::s_instance = nullptr;
 VGAController::VGAController()
 {
   s_instance = this;
+  m_linesCount = VGA64_LinesCount;
+  m_lines = (volatile uint8_t**) heap_caps_malloc(sizeof(uint8_t*) * m_linesCount, MALLOC_CAP_32BIT | MALLOC_CAP_INTERNAL);
 }
 
+VGAController::~VGAController() {
+  heap_caps_free(m_lines);
+}
 
 void VGAController::init()
 {
   VGABaseController::init();
 
   m_doubleBufferOverDMA = true;
+}
+
+// make sure view port height is divisible by m_linesCount
+void VGAController::checkViewPortSize()
+{
+  m_viewPortHeight &= ~(m_linesCount - 1);
 }
 
 
@@ -91,7 +102,7 @@ void VGAController::resumeBackgroundPrimitiveExecution()
   VGABaseController::resumeBackgroundPrimitiveExecution();
   if (m_primitiveProcessingSuspended == 0) {
     if (m_isr_handle == nullptr)
-      esp_intr_alloc(ETS_I2S1_INTR_SOURCE, ESP_INTR_FLAG_LEVEL1, VSyncInterrupt, this, &m_isr_handle);
+      esp_intr_alloc(ETS_I2S1_INTR_SOURCE, ESP_INTR_FLAG_LEVEL1, ISRHandler, this, &m_isr_handle);
     I2S1.int_clr.val     = 0xFFFFFFFF;
     I2S1.int_ena.out_eof = 1;
   }
@@ -100,7 +111,21 @@ void VGAController::resumeBackgroundPrimitiveExecution()
 
 void VGAController::allocateViewPort()
 {
-  VGABaseController::allocateViewPort(MALLOC_CAP_DMA, m_viewPortWidth);
+  VGABaseController::allocateViewPort(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL, m_viewPortWidth);
+
+  for (int i = 0; i < m_linesCount; ++i)
+    m_lines[i] = (uint8_t*) heap_caps_malloc(m_viewPortWidth, MALLOC_CAP_DMA);
+}
+
+
+void VGAController::freeViewPort()
+{
+  VGABaseController::freeViewPort();
+
+  for (int i = 0; i < m_linesCount; ++i) {
+    heap_caps_free((void*)m_lines[i]);
+    m_lines[i] = nullptr;
+  }
 }
 
 
@@ -122,30 +147,74 @@ void VGAController::setResolution(VGATimings const& timings, int viewPortWidth, 
 
 void VGAController::onSetupDMABuffer(lldesc_t volatile * buffer, bool isStartOfVertFrontPorch, int scan, bool isVisible, int visibleRow)
 {
+  if (isVisible) {
+    buffer->buf = (uint8_t *) m_lines[visibleRow % m_linesCount];
+
+    // generate interrupt every half m_linesCount
+    if ((scan == 0 && (visibleRow % (m_linesCount / 2)) == 0)) {
+      if (visibleRow == 0)
+        s_frameResetDesc = buffer;
+      buffer->eof = 1;
+    }
+  }
+
   // generate interrupt at the beginning of vertical front porch
-  if (isStartOfVertFrontPorch)
+  if (isStartOfVertFrontPorch) {
     buffer->eof = 1;
+  }
 }
 
 
-void IRAM_ATTR VGAController::VSyncInterrupt(void * arg)
+void IRAM_ATTR VGAController::ISRHandler(void * arg)
 {
   if (I2S1.int_st.out_eof) {
-    auto VGACtrl = (VGAController*)arg;
-    int64_t startTime = VGACtrl->backgroundPrimitiveTimeoutEnabled() ? esp_timer_get_time() : 0;
-    Rect updateRect = Rect(SHRT_MAX, SHRT_MAX, SHRT_MIN, SHRT_MIN);
-    do {
-      Primitive prim;
-      if (VGACtrl->getPrimitiveISR(&prim) == false)
-        break;
+    auto ctrl = (VGAController*)arg;
+    auto const width  = ctrl->m_viewPortWidth;
+    auto const height = ctrl->m_viewPortHeight;
 
-      VGACtrl->execPrimitive(prim, updateRect, true);
+    // Determine whether we are handling a scan line or blanking area
+    auto const desc = (lldesc_t*) I2S1.out_eof_des_addr;
 
-      if (VGACtrl->m_primitiveProcessingSuspended)
-        break;
+    if (desc == s_frameResetDesc) {
+      // Start new frame
+      s_scanLine = 0;
+      s_scanRow = 0;
+    }
+    
+    if (s_scanRow >= height) {
+      // Handle primitives in the background
+      int64_t startTime = ctrl->backgroundPrimitiveTimeoutEnabled() ? esp_timer_get_time() : 0;
+      Rect updateRect = Rect(SHRT_MAX, SHRT_MAX, SHRT_MIN, SHRT_MIN);
+      do {
+        Primitive prim;
+        if (ctrl->getPrimitiveISR(&prim) == false)
+          break;
 
-    } while (!VGACtrl->backgroundPrimitiveTimeoutEnabled() || (startTime + VGACtrl->m_maxVSyncISRTime > esp_timer_get_time()));
-    VGACtrl->showSprites(updateRect);
+        ctrl->execPrimitive(prim, updateRect, true);
+
+        if (ctrl->m_primitiveProcessingSuspended)
+          break;
+      } while (!ctrl->backgroundPrimitiveTimeoutEnabled() || (startTime + ctrl->m_maxVSyncISRTime > esp_timer_get_time()));
+      ctrl->showSprites(updateRect);
+    } else {
+      // Process scan lines
+      int scanLine = (s_scanLine + VGA64_LinesCount / 2) % height;
+      auto lineIndex = scanLine & (VGA64_LinesCount - 1);
+
+      for (int i = 0; i < VGA64_LinesCount / 2; ++i) {
+
+        auto src  = (uint8_t const *) s_viewPortVisible[scanLine];
+        auto decpix = (uint8_t*) ctrl->m_lines[lineIndex];
+        memset(decpix, ctrl->m_HVSync, width);
+        ctrl->decorateScanLinePixels(decpix);
+
+        ++lineIndex;
+        ++scanLine;
+        ++s_scanRow;
+      }
+
+      s_scanLine += VGA64_LinesCount / 2;
+    }
   }
   I2S1.int_clr.val = I2S1.int_st.val;
 }

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -133,6 +133,9 @@ void VGAController::setResolution(VGATimings const& timings, int viewPortWidth, 
 {
   VGABaseController::setResolution(timings, viewPortWidth, viewPortHeight, doubleBuffered);
 
+  s_viewPort        = m_viewPort;
+  s_viewPortVisible = m_viewPortVisible;
+
   // fill view port
   for (int i = 0; i < m_viewPortHeight; ++i)
     fill(m_viewPort[i], 0, m_viewPortWidth, 0, 0, 0, false, false);
@@ -203,9 +206,9 @@ void IRAM_ATTR VGAController::ISRHandler(void * arg)
 
       for (int i = 0; i < VGA64_LinesCount / 2; ++i) {
 
-        auto src  = (uint8_t const *) s_viewPortVisible[scanLine];
+        auto src = (uint8_t const *) s_viewPortVisible[scanLine];
         auto decpix = (uint8_t*) ctrl->m_lines[lineIndex];
-        memset(decpix, ctrl->m_HVSync, width);
+        memset(decpix, 0x10|ctrl->m_HVSync, width);
         ctrl->decorateScanLinePixels(decpix);
 
         ++lineIndex;

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -52,6 +52,7 @@
 #include "dispdrivers/vgabasecontroller.h"
 
 
+#define VGA64_LinesCount 4
 
 
 namespace fabgl {
@@ -92,6 +93,7 @@ class VGAController : public VGABaseController {
 public:
 
   VGAController();
+  ~VGAController();
 
   // unwanted methods
   VGAController(VGAController const&)   = delete;
@@ -199,6 +201,8 @@ private:
   void init();
 
   void allocateViewPort();
+  void freeViewPort();
+  void checkViewPortSize();
   void onSetupDMABuffer(lldesc_t volatile * buffer, bool isStartOfVertFrontPorch, int scan, bool isVisible, int visibleRow);
 
   // methods to get lambdas to get/set pixels
@@ -288,8 +292,7 @@ private:
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }
 
-  static void VSyncInterrupt(void * arg);
-
+  static void ISRHandler(void * arg);
 
 
   static VGAController * s_instance;

--- a/src/dispdrivers/vgapalettedcontroller.cpp
+++ b/src/dispdrivers/vgapalettedcontroller.cpp
@@ -60,14 +60,6 @@ namespace fabgl {
 /* VGAPalettedController definitions */
 
 
-volatile uint8_t * * VGAPalettedController::s_viewPort;
-volatile uint8_t * * VGAPalettedController::s_viewPortVisible;
-lldesc_t volatile *  VGAPalettedController::s_frameResetDesc;
-volatile int         VGAPalettedController::s_scanLine;
-
-
-
-
 VGAPalettedController::VGAPalettedController(int linesCount, int columnsQuantum, NativePixelFormat nativePixelFormat, int viewPortRatioDiv, int viewPortRatioMul, intr_handler_t isrHandler)
   : m_linesCount(linesCount),
     m_columnsQuantum(columnsQuantum),

--- a/src/dispdrivers/vgapalettedcontroller.cpp
+++ b/src/dispdrivers/vgapalettedcontroller.cpp
@@ -61,13 +61,13 @@ namespace fabgl {
 
 
 VGAPalettedController::VGAPalettedController(int linesCount, int columnsQuantum, NativePixelFormat nativePixelFormat, int viewPortRatioDiv, int viewPortRatioMul, intr_handler_t isrHandler)
-  : m_linesCount(linesCount),
-    m_columnsQuantum(columnsQuantum),
+  : m_columnsQuantum(columnsQuantum),
     m_nativePixelFormat(nativePixelFormat),
     m_viewPortRatioDiv(viewPortRatioDiv),
     m_viewPortRatioMul(viewPortRatioMul),
     m_isrHandler(isrHandler)
 {
+  m_linesCount = linesCount;
   m_lines   = (volatile uint8_t**) heap_caps_malloc(sizeof(uint8_t*) * m_linesCount, MALLOC_CAP_32BIT | MALLOC_CAP_INTERNAL);
   m_palette = (RGB222*) heap_caps_malloc(sizeof(RGB222) * getPaletteSize(), MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 }

--- a/src/dispdrivers/vgapalettedcontroller.h
+++ b/src/dispdrivers/vgapalettedcontroller.h
@@ -137,16 +137,6 @@ protected:
 
   TaskHandle_t                m_primitiveExecTask;
 
-  volatile uint8_t * *        m_lines;
-
-  // optimization: clones of m_viewPort and m_viewPortVisible
-  static volatile uint8_t * * s_viewPort;
-  static volatile uint8_t * * s_viewPortVisible;
-
-  static lldesc_t volatile *  s_frameResetDesc;
-
-  static volatile int         s_scanLine;
-
   RGB222 *                    m_palette;
 
 

--- a/src/dispdrivers/vgapalettedcontroller.h
+++ b/src/dispdrivers/vgapalettedcontroller.h
@@ -159,7 +159,6 @@ private:
   uint8_t                     m_packedRGB222_to_PaletteIndex[64];
 
   // configuration
-  int                         m_linesCount;     // viewport height must be divisible by m_linesCount
   int                         m_columnsQuantum; // viewport width must be divisble by m_columnsQuantum
   NativePixelFormat           m_nativePixelFormat;
   int                         m_viewPortRatioDiv;

--- a/src/dispdrivers/vgapalettedcontroller.h
+++ b/src/dispdrivers/vgapalettedcontroller.h
@@ -116,9 +116,6 @@ protected:
 
   virtual void setupDefaultPalette() = 0;
 
-  void calculateAvailableCyclesForDrawings();
-  static void primitiveExecTask(void * arg);
-
   uint8_t RGB888toPaletteIndex(RGB888 const & rgb) {
     return m_packedRGB222_to_PaletteIndex[RGB888toPackedRGB222(rgb)];
   }
@@ -135,8 +132,6 @@ protected:
   void swapBuffers();
 
 
-  TaskHandle_t                m_primitiveExecTask;
-
   RGB222 *                    m_palette;
 
 
@@ -146,15 +141,6 @@ private:
   void freeViewPort();
   void checkViewPortSize();
   void onSetupDMABuffer(lldesc_t volatile * buffer, bool isStartOfVertFrontPorch, int scan, bool isVisible, int visibleRow);
-
-  // Maximum time (in CPU cycles) available for primitives drawing
-  volatile uint32_t           m_primitiveExecTimeoutCycles;
-
-  volatile bool               m_taskProcessingPrimitives;
-
-  // true = allowed time to process primitives is limited to the vertical blank. Slow, but avoid flickering
-  // false = allowed time is the half of an entire frame. Fast, but may flick
-  bool                        m_processPrimitivesOnBlank;
 
   uint8_t                     m_packedRGB222_to_PaletteIndex[64];
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -816,14 +816,11 @@ void BitmappedDisplayController::setMouseCursorPos(int X, int Y)
 
 void BitmappedDisplayController::drawSpriteScanLine(uint8_t * pixelData, int scanRow, int scanWidth, int viewportHeight) {
     // normal sprites
-pixelData[13] = 0x30 | m_HVSync;
     int spritesCnt = spritesCount();
     for (int i = 0; i < spritesCnt; ++i) {
-pixelData[19] = 0x03 | m_HVSync;
       Sprite * sprite = getSprite(i);
       if (sprite->hardware &&
           sprite->visible && sprite->allowDraw && sprite->getFrame()) {
-pixelData[22] = 0x0C | m_HVSync;
         auto spriteFrame = sprite->getFrame();
         int spriteWidth = spriteFrame->width;
         int spriteHeight = spriteFrame->height;

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -816,11 +816,14 @@ void BitmappedDisplayController::setMouseCursorPos(int X, int Y)
 
 void BitmappedDisplayController::drawSpriteScanLine(uint8_t * pixelData, int scanRow, int scanWidth, int viewportHeight) {
     // normal sprites
+pixelData[13] = 0x30 | m_HVSync;
     int spritesCnt = spritesCount();
     for (int i = 0; i < spritesCnt; ++i) {
+pixelData[19] = 0x03 | m_HVSync;
       Sprite * sprite = getSprite(i);
       if (sprite->hardware &&
           sprite->visible && sprite->allowDraw && sprite->getFrame()) {
+pixelData[22] = 0x0C | m_HVSync;
         auto spriteFrame = sprite->getFrame();
         int spriteWidth = spriteFrame->width;
         int spriteHeight = spriteFrame->height;

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -844,16 +844,16 @@ void BitmappedDisplayController::drawSpriteScanLine(uint8_t * pixelData, int sca
 
         switch (spriteFrame->format) {
           case PixelFormat::RGBA8888: {
-              auto src = spriteFrame->data + (offsetY * spriteWidth * 4) + (offsetX * 4);
+              auto src = (const uint32_t*)(spriteFrame->data) + (offsetY * spriteWidth) + offsetX;
               auto pos = spriteX + offsetX;
               while (drawWidth--) {
-                if (src[3]) {
-                  auto r = src[0] >> 6;
-                  auto g = (src[1] >> 6) << 2;
-                  auto b = (src[2] >> 6) << 4;
-                  pixelData[pos ^ 2] = r | g | b | m_HVSync;
+                auto src_pix = *src++;
+                if (src_pix & 0xFF000000) {
+                  auto r = (src_pix & 0x000000C0) >> (8-2);
+                  auto g = (src_pix & 0x0000C000) >> (16-4);
+                  auto b = (src_pix & 0x00C00000) >> (24-6);
+                  pixelData[pos^2] = r | g | b | m_HVSync;
                 }
-                src += 4;
                 pos++;
               }
             }

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -842,12 +842,10 @@ void BitmappedDisplayController::drawSpriteScanLine(uint8_t * pixelData, int sca
             scanWidth - spriteX :
             spriteWidth - offsetX);
 
-        auto pos = spriteX + offsetX;
-
         switch (spriteFrame->format) {
           case PixelFormat::RGBA8888: {
               auto src = spriteFrame->data + (offsetY * spriteWidth * 4) + (offsetX * 4);
-
+              auto pos = spriteX + offsetX;
               while (drawWidth--) {
                 if (src[3]) {
                   auto r = src[0] >> 6;
@@ -863,14 +861,41 @@ void BitmappedDisplayController::drawSpriteScanLine(uint8_t * pixelData, int sca
 
           case PixelFormat::RGBA2222: {
               auto src = spriteFrame->data + (offsetY * spriteWidth) + offsetX;
+              pixelData += spriteX + offsetX;
+              auto hv4 = (((uint32_t) m_HVSync) << 24) |
+                        (((uint32_t) m_HVSync) << 16) |
+                        (((uint32_t) m_HVSync) << 8) |
+                        ((uint32_t) m_HVSync);
 
-              while (drawWidth--) {
+              while (drawWidth) {
+                if (drawWidth >= 4 && !((uint32_t)(void*)pixelData & 3))
+                {
+                  // Do a full word (4 pixels)
+                  auto src_pix = *((uint32_t*)src);
+                  auto alphas = src_pix & 0xC0C0C0C0; 
+                  if (alphas == 0xC0C0C0C0) {
+                    src_pix = (src_pix & 0x3F3F3F3F) | hv4; 
+                    *((uint32_t*)pixelData) = (src_pix << 16) | (src_pix >> 16);
+                    src += 4;
+                    pixelData += 4;
+                    drawWidth -= 4;
+                    continue;
+                  } else if (alphas == 0x00000000) {
+                    src += 4;
+                    pixelData += 4;
+                    drawWidth -= 4;
+                    continue;
+                  }
+                }
+
+                // Just do a single byte (1 pixel)
                 if (*src & 0xC0) {
                   auto rgb = *src & 0x3F;
-                  pixelData[pos ^ 2] = rgb | m_HVSync;
+                  *((uint8_t*)(((uint32_t)(void*)pixelData)^2)) = rgb | m_HVSync;
                 }
                 src++;
-                pos++;
+                pixelData++;
+                drawWidth--;
               }
             }
             break;

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -842,18 +842,38 @@ void BitmappedDisplayController::drawSpriteScanLine(uint8_t * pixelData, int sca
             scanWidth - spriteX :
             spriteWidth - offsetX);
 
-        auto src = spriteFrame->data + (offsetY * spriteWidth * 4) + (offsetX * 4);
         auto pos = spriteX + offsetX;
 
-        while (drawWidth--) {
-          if (src[3]) {
-            auto r = src[0] >> 6;
-            auto g = (src[1] >> 6) << 2;
-            auto b = (src[2] >> 6) << 4;
-            pixelData[pos ^ 2] = r | g | b | m_HVSync;
-          }
-          src += 4;
-          pos++;
+        switch (spriteFrame->format) {
+          case PixelFormat::RGBA8888: {
+              auto src = spriteFrame->data + (offsetY * spriteWidth * 4) + (offsetX * 4);
+
+              while (drawWidth--) {
+                if (src[3]) {
+                  auto r = src[0] >> 6;
+                  auto g = (src[1] >> 6) << 2;
+                  auto b = (src[2] >> 6) << 4;
+                  pixelData[pos ^ 2] = r | g | b | m_HVSync;
+                }
+                src += 4;
+                pos++;
+              }
+            }
+            break;
+
+          case PixelFormat::RGBA2222: {
+              auto src = spriteFrame->data + (offsetY * spriteWidth) + offsetX;
+
+              while (drawWidth--) {
+                if (*src & 0xC0) {
+                  auto rgb = *src & 0x3F;
+                  pixelData[pos ^ 2] = rgb | m_HVSync;
+                }
+                src++;
+                pos++;
+              }
+            }
+            break;
         }
       }
     }

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -645,6 +645,8 @@ struct Sprite {
     uint8_t isStatic:  1;
     // This is always '1' for dynamic sprites and always '0' for static sprites.
     uint8_t allowDraw: 1;
+    // This tells the system to draw it as a hardware sprite (on-the-fly).
+    uint8_t hardware:  1;
   };
 
   Sprite();
@@ -816,6 +818,9 @@ protected:
   int16_t          m_screenHeight;
   volatile int16_t m_viewPortWidth;
   volatile int16_t m_viewPortHeight;
+
+  // contains H and V signals for visible line
+  volatile uint8_t m_HVSync;
 };
 
 
@@ -1098,6 +1103,8 @@ protected:
   void hideSprites(Rect & updateRect);
 
   void showSprites(Rect & updateRect);
+
+  void drawSpriteScanLine(uint8_t * pixelData, int scanRow, int scanWidth, int viewportHeight);
 
   void drawBitmap(BitmapDrawingInfo const & bitmapDrawingInfo, Rect & updateRect);
 


### PR DESCRIPTION
This change adds hardware sprites, meaning that they are drawn by software, but only 1 scan line at a time, based on hardware interrupts. Regular software sprites are still supported.