### PR TITLE
Use hardware sprites for cursors

### DIFF
--- a/src/dispdrivers/vgapalettedcontroller.cpp
+++ b/src/dispdrivers/vgapalettedcontroller.cpp
@@ -406,67 +406,76 @@ void IRAM_ATTR VGAPalettedController::decorateScanLinePixels(uint8_t * pixels, u
   drawSpriteScanLine(pixels, scanRow, s_scanWidth, s_viewPortHeight);
 }
 
+void IRAM_ATTR VGAPalettedController::rawDrawSpriteScanline(uint8_t * pixelData, Sprite * sprite, int scanRow, int scanWidth, int viewportHeight) {
+  auto spriteFrame = sprite->getFrame();
+  if (!spriteFrame) {
+    return;
+  }
+  int spriteWidth = spriteFrame->width;
+  int spriteHeight = spriteFrame->height;
+
+  int spriteY = sprite->y;
+  int spriteYend = spriteY + spriteHeight;
+  if (scanRow < spriteY) return;
+  if (scanRow >= spriteYend) return;
+  int offsetY = scanRow - spriteY;
+
+  int spriteX = sprite->x;
+  if (spriteX >= scanWidth) return;
+  int spriteXend = spriteX + spriteWidth;
+  if (spriteXend <= 0) return;
+
+  int offsetX = spriteX < 0 ? -spriteX : 0;
+  int drawWidth = spriteXend > scanWidth ?
+      scanWidth - spriteX :
+      spriteWidth - offsetX;
+  if (drawWidth <= 0) return;
+
+  switch (spriteFrame->format) {
+    case PixelFormat::RGBA8888: {
+        auto src = (const uint32_t*)(spriteFrame->data) + (offsetY * spriteWidth) + offsetX;
+        auto pos = spriteX + offsetX;
+        while (drawWidth--) {
+          auto src_pix = *src++;
+          if (src_pix & 0xFF000000) {
+            auto r = (src_pix & 0x000000C0) >> (8-2);
+            auto g = (src_pix & 0x0000C000) >> (16-4);
+            auto b = (src_pix & 0x00C00000) >> (24-6);
+            pixelData[pos^2] = r | g | b | m_HVSync;
+          }
+          pos++;
+        }
+      }
+      break;
+
+    case PixelFormat::RGBA2222: {
+        auto src = spriteFrame->data + (offsetY * spriteWidth) + offsetX;
+        auto pos = spriteX + offsetX;
+        while (drawWidth--) {
+          if (*src & 0xC0) {
+            auto rgb = *src & 0x3F;
+            pixelData[pos^2] = rgb | m_HVSync;
+          }
+          src++;
+          pos++;
+        }
+      }
+      break;
+  }
+}
 
 void IRAM_ATTR VGAPalettedController::drawSpriteScanLine(uint8_t * pixelData, int scanRow, int scanWidth, int viewportHeight) {
   // normal sprites
   for (int i = 0; i < spritesCount(); ++i) {
     Sprite * sprite = getSprite(i);
-    if (sprite->hardware &&
-        sprite->visible && sprite->allowDraw && sprite->getFrame()) {
-      auto spriteFrame = sprite->getFrame();
-      int spriteWidth = spriteFrame->width;
-      int spriteHeight = spriteFrame->height;
-
-      int spriteY = sprite->y;
-      int spriteYend = spriteY + spriteHeight;
-      if (scanRow < spriteY) continue;
-      if (scanRow >= spriteYend) continue;
-      int offsetY = scanRow - spriteY;
-
-      int spriteX = sprite->x;
-      if (spriteX >= scanWidth) continue;
-      int spriteXend = spriteX + spriteWidth;
-      if (spriteXend <= 0) continue;
-
-      int offsetX = (spriteX < 0 ? -spriteX : 0);
-      int drawWidth =
-        (spriteXend > scanWidth ?
-          scanWidth - spriteX :
-          spriteWidth - offsetX);
-      if (drawWidth <= 0) continue;
-
-      switch (spriteFrame->format) {
-        case PixelFormat::RGBA8888: {
-            auto src = (const uint32_t*)(spriteFrame->data) + (offsetY * spriteWidth) + offsetX;
-            auto pos = spriteX + offsetX;
-            while (drawWidth--) {
-              auto src_pix = *src++;
-              if (src_pix & 0xFF000000) {
-                auto r = (src_pix & 0x000000C0) >> (8-2);
-                auto g = (src_pix & 0x0000C000) >> (16-4);
-                auto b = (src_pix & 0x00C00000) >> (24-6);
-                pixelData[pos^2] = r | g | b | m_HVSync;
-              }
-              pos++;
-            }
-          }
-          break;
-
-        case PixelFormat::RGBA2222: {
-            auto src = spriteFrame->data + (offsetY * spriteWidth) + offsetX;
-            auto pos = spriteX + offsetX;
-            while (drawWidth--) {
-              if (*src & 0xC0) {
-                auto rgb = *src & 0x3F;
-                pixelData[pos^2] = rgb | m_HVSync;
-              }
-              src++;
-              pos++;
-            }
-          }
-          break;
-      }
+    if (sprite->hardware && sprite->visible && sprite->allowDraw) {
+      rawDrawSpriteScanline(pixelData, sprite, scanRow, scanWidth, viewportHeight);
     }
+  }
+  // mouse cursor
+  auto mouse = mouseCursor();
+  if (mouse->visible) {
+    rawDrawSpriteScanline(pixelData, mouse, scanRow, scanWidth, viewportHeight);
   }
 }
 

--- a/src/dispdrivers/vgapalettedcontroller.cpp
+++ b/src/dispdrivers/vgapalettedcontroller.cpp
@@ -451,13 +451,26 @@ void IRAM_ATTR VGAPalettedController::rawDrawSpriteScanline(uint8_t * pixelData,
     case PixelFormat::RGBA2222: {
         auto src = spriteFrame->data + (offsetY * spriteWidth) + offsetX;
         auto pos = spriteX + offsetX;
-        while (drawWidth--) {
-          if (*src & 0xC0) {
-            auto rgb = *src & 0x3F;
-            pixelData[pos^2] = rgb | m_HVSync;
+        if (sprite->paintOptions.mode == PaintMode::XOR) {
+          // XOR mode
+          while (drawWidth--) {
+            if (*src & 0xC0) {
+              auto rgb = *src & 0x3F;
+              pixelData[pos^2] ^= rgb;
+            }
+            src++;
+            pos++;
           }
-          src++;
-          pos++;
+        } else {
+          // normal mode
+          while (drawWidth--) {
+            if (*src & 0xC0) {
+              auto rgb = *src & 0x3F;
+              pixelData[pos^2] = rgb | m_HVSync;
+            }
+            src++;
+            pos++;
+          }
         }
       }
       break;

--- a/src/dispdrivers/vgapalettedcontroller.cpp
+++ b/src/dispdrivers/vgapalettedcontroller.cpp
@@ -478,6 +478,12 @@ void IRAM_ATTR VGAPalettedController::rawDrawSpriteScanline(uint8_t * pixelData,
 }
 
 void IRAM_ATTR VGAPalettedController::drawSpriteScanLine(uint8_t * pixelData, int scanRow, int scanWidth, int viewportHeight) {
+  // text cursor
+  auto text = textCursor();
+  if (text && text->visible) {
+    rawDrawSpriteScanline(pixelData, text, scanRow, scanWidth, viewportHeight);
+  }
+
   // normal sprites
   for (int i = 0; i < spritesCount(); ++i) {
     Sprite * sprite = getSprite(i);

--- a/src/dispdrivers/vgapalettedcontroller.h
+++ b/src/dispdrivers/vgapalettedcontroller.h
@@ -205,6 +205,7 @@ private:
   PaletteListItem * createSignalList(uint16_t * rawList, int entries, int row = 0);
   void deleteSignalList(PaletteListItem * item);
 
+  void rawDrawSpriteScanline(uint8_t * pixelData, Sprite * sprite, int scanRow, int scanWidth, int viewportHeight);
   void drawSpriteScanLine(uint8_t * pixelData, int scanRow, int scanWidth, int viewportHeight);
 
   uint8_t                     m_packedRGB222_to_PaletteIndex[64];

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -477,6 +477,7 @@ BitmappedDisplayController::BitmappedDisplayController()
   m_spritesCount                        = 0;
   m_doubleBuffered                      = false;
   m_mouseCursor.visible                 = false;
+  m_mouseCursor.hardware                = true;
   m_backgroundPrimitiveTimeoutEnabled   = true;
   m_spritesHidden                       = true;
 }
@@ -714,19 +715,6 @@ void IRAM_ATTR BitmappedDisplayController::hideSprites(Rect & updateRect)
         }
       }
     }
-
-    // mouse cursor sprite
-    Sprite * mouseSprite = mouseCursor();
-    if (mouseSprite->savedBackgroundWidth > 0) {
-      int savedX = mouseSprite->savedX;
-      int savedY = mouseSprite->savedY;
-      int savedWidth  = mouseSprite->savedBackgroundWidth;
-      int savedHeight = mouseSprite->savedBackgroundHeight;
-      Bitmap bitmap(savedWidth, savedHeight, mouseSprite->savedBackground, PixelFormat::Native);
-      absDrawBitmap(savedX, savedY, &bitmap, nullptr, true);
-      updateRect = updateRect.merge(Rect(savedX, savedY, savedX + savedWidth - 1, savedY + savedHeight - 1));
-      mouseSprite->savedBackgroundWidth = mouseSprite->savedBackgroundHeight = 0;
-    }
   }
 }
 
@@ -761,25 +749,6 @@ void IRAM_ATTR BitmappedDisplayController::showSprites(Rect & updateRect)
       }
     }
 
-    // mouse cursor sprite
-    // save backgrounds and draw mouse cursor
-    Sprite * mouseSprite = mouseCursor();
-    if (mouseSprite->visible && mouseSprite->getFrame()) {
-      // save sprite X and Y so other threads can change them without interferring
-      int spriteX = mouseSprite->x;
-      int spriteY = mouseSprite->y;
-      Bitmap const * bitmap = mouseSprite->getFrame();
-      int bitmapWidth  = bitmap->width;
-      int bitmapHeight = bitmap->height;
-      paintState().paintOptions = PaintOptions();
-      absDrawBitmap(spriteX, spriteY, bitmap, mouseSprite->savedBackground, true);
-      mouseSprite->savedX = spriteX;
-      mouseSprite->savedY = spriteY;
-      mouseSprite->savedBackgroundWidth  = bitmapWidth;
-      mouseSprite->savedBackgroundHeight = bitmapHeight;
-      updateRect = updateRect.merge(Rect(spriteX, spriteY, spriteX + bitmapWidth - 1, spriteY + bitmapHeight - 1));
-    }
-
     paintState().paintOptions = options;
   }
 }
@@ -792,21 +761,14 @@ void BitmappedDisplayController::setMouseCursor(Cursor * cursor)
     m_mouseCursor.visible = false;
     m_mouseCursor.clearBitmaps();
 
-    refreshSprites();
-    processPrimitives();
-    primitivesExecutionWait();
-
     if (cursor) {
       m_mouseCursor.moveBy(+m_mouseHotspotX, +m_mouseHotspotY);
       m_mouseHotspotX = cursor->hotspotX;
       m_mouseHotspotY = cursor->hotspotY;
       m_mouseCursor.addBitmap(&cursor->bitmap);
-      m_mouseCursor.visible = true;
       m_mouseCursor.moveBy(-m_mouseHotspotX, -m_mouseHotspotY);
-      if (!isDoubleBuffered())
-        m_mouseCursor.savedBackground = (uint8_t*) realloc(m_mouseCursor.savedBackground, cursor->bitmap.width * getBitmapSavePixelSize() * cursor->bitmap.height);
+      m_mouseCursor.visible = true;
     }
-    refreshSprites();
   }
 }
 
@@ -820,7 +782,6 @@ void BitmappedDisplayController::setMouseCursor(CursorName cursorName)
 void BitmappedDisplayController::setMouseCursorPos(int X, int Y)
 {
   m_mouseCursor.moveTo(X - m_mouseHotspotX, Y - m_mouseHotspotY);
-  refreshSprites();
 }
 
 

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -478,6 +478,7 @@ BitmappedDisplayController::BitmappedDisplayController()
   m_doubleBuffered                      = false;
   m_mouseCursor.visible                 = false;
   m_mouseCursor.hardware                = true;
+  m_textCursor                          = nullptr;  
   m_backgroundPrimitiveTimeoutEnabled   = true;
   m_spritesHidden                       = true;
 }

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -1122,7 +1122,7 @@ protected:
 
   void waitForPrimitives();
 
-  Sprite * mouseCursor() { return &m_mouseCursor; }
+  inline Sprite * mouseCursor() { return &m_mouseCursor; }
 
   void resetPaintState();
 

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -999,6 +999,13 @@ public:
    */
   void setMouseCursorPos(int X, int Y);
 
+  /**
+   * @brief Set the text cursor sprite
+   * 
+   * @param sprite The sprite to use as text cursor. nullptr = disable text cursor.
+   */
+  void setTextCursor(Sprite * sprite) { m_textCursor = sprite; }
+
   virtual void readScreen(Rect const & rect, RGB888 * destBuf) = 0;
 
 
@@ -1124,6 +1131,8 @@ protected:
 
   inline Sprite * mouseCursor() { return &m_mouseCursor; }
 
+  inline Sprite * textCursor() { return m_textCursor; }
+
   void resetPaintState();
 
 private:
@@ -1148,6 +1157,9 @@ private:
   Sprite                 m_mouseCursor;
   int16_t                m_mouseHotspotX;
   int16_t                m_mouseHotspotY;
+  
+  // Optional hardware text cursor sprite
+  Sprite *               m_textCursor;
 
   // memory pool used to allocate buffers of primitives
   LightMemoryPool        m_primDynMemPool;

--- a/src/fabglconf.h
+++ b/src/fabglconf.h
@@ -144,7 +144,8 @@
 
 
 /** Stack size of primitives drawing task of paletted based VGA controllers */
-#define FABGLIB_VGAPALETTEDCONTROLLER_PRIMTASK_STACK_SIZE 1200
+/** This needs to be large enough for the local variable needs of all our primitive drawing functions, plus some extra workspace */
+#define FABGLIB_VGAPALETTEDCONTROLLER_PRIMTASK_STACK_SIZE 3000
 
 
 /** Priority of primitives drawing task of paletted based VGA controllers */


### PR DESCRIPTION
Changes the mouse cursor to use a hardware sprite.

Also adds support for a hardware sprite _text_ cursor.

If a text cursor sprite has been set, it will always be the first hardware sprite drawn, thus sits at the bottom of the stack.  Similarly if the mouse cursor is enabled, it is drawn after all other hardware sprites, so will always be at the top.

These changes mean that the mouse cursor will no longer be visible in VGAController, as the software-sprite based approach has been deleted.  as we don’t use that for the agon VDP any longer that seems like a sensible/reasonable compromise.

By default no text cursor sprite will be set up.  The positioning and appearance of this sprite is not managed at all inside vdp-gl - it is just simply a special hardware sprite that is guaranteed to be drawn first.

Hardware sprite plotting now supports XOR painting mode for RGBA2222 bitmaps.  The agon-vdp uses this for it's text cursor, as that uses an XOR plot.  (It is not planned to add support for any other painting modes, or to support XOR for RGBA8888 format sprites.)

This PR also changes the value of `FABGLIB_VGAPALETTEDCONTROLLER_PRIMTASK_STACK_SIZE` - as it had been found that the previous size was not large enough.  This change fixes a bug whereby attempting to draw a filled sector would crash the VDP