### PR TITLE
change mouse cursor sprite to be a pointer

### DIFF
--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -476,11 +476,13 @@ BitmappedDisplayController::BitmappedDisplayController()
   m_sprites                             = nullptr;
   m_spritesCount                        = 0;
   m_doubleBuffered                      = false;
-  m_mouseCursor.visible                 = false;
-  m_mouseCursor.hardware                = true;
   m_textCursor                          = nullptr;  
   m_backgroundPrimitiveTimeoutEnabled   = true;
   m_spritesHidden                       = true;
+  // Create a mouse cursor sprite - must be in internal memory for hardware cursor support
+  m_mouseCursor = new Sprite();
+  m_mouseCursor->visible                 = false;
+  m_mouseCursor->hardware                = true;
 }
 
 
@@ -758,17 +760,17 @@ void IRAM_ATTR BitmappedDisplayController::showSprites(Rect & updateRect)
 // cursor = nullptr -> disable mouse
 void BitmappedDisplayController::setMouseCursor(Cursor * cursor)
 {
-  if (cursor == nullptr || &cursor->bitmap != m_mouseCursor.getFrame()) {
-    m_mouseCursor.visible = false;
-    m_mouseCursor.clearBitmaps();
+  if (cursor == nullptr || &cursor->bitmap != m_mouseCursor->getFrame()) {
+    m_mouseCursor->visible = false;
+    m_mouseCursor->clearBitmaps();
 
     if (cursor) {
-      m_mouseCursor.moveBy(+m_mouseHotspotX, +m_mouseHotspotY);
+      m_mouseCursor->moveBy(+m_mouseHotspotX, +m_mouseHotspotY);
       m_mouseHotspotX = cursor->hotspotX;
       m_mouseHotspotY = cursor->hotspotY;
-      m_mouseCursor.addBitmap(&cursor->bitmap);
-      m_mouseCursor.moveBy(-m_mouseHotspotX, -m_mouseHotspotY);
-      m_mouseCursor.visible = true;
+      m_mouseCursor->addBitmap(&cursor->bitmap);
+      m_mouseCursor->moveBy(-m_mouseHotspotX, -m_mouseHotspotY);
+      m_mouseCursor->visible = true;
     }
   }
 }
@@ -782,7 +784,7 @@ void BitmappedDisplayController::setMouseCursor(CursorName cursorName)
 
 void BitmappedDisplayController::setMouseCursorPos(int X, int Y)
 {
-  m_mouseCursor.moveTo(X - m_mouseHotspotX, Y - m_mouseHotspotY);
+  m_mouseCursor->moveTo(X - m_mouseHotspotX, Y - m_mouseHotspotY);
 }
 
 

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -1129,7 +1129,7 @@ protected:
 
   void waitForPrimitives();
 
-  inline Sprite * mouseCursor() { return &m_mouseCursor; }
+  inline Sprite * mouseCursor() { return m_mouseCursor; }
 
   inline Sprite * textCursor() { return m_textCursor; }
 
@@ -1154,7 +1154,7 @@ private:
   bool                   m_spritesHidden; // true between hideSprites() and showSprites()
 
   // mouse cursor (mouse pointer) support
-  Sprite                 m_mouseCursor;
+  Sprite *               m_mouseCursor;
   int16_t                m_mouseHotspotX;
   int16_t                m_mouseHotspotY;
   


### PR DESCRIPTION
in principle i think this should be more robust

I made these changes some time ago - I think during when we'd discovered issues with the hardware cursors and the firmware upgrade process via the Agon-flash tool.  I can't entirely remember whether this change helped right now - but it at least makes the code for handling the two cursors a bit more consistent 🤷