### PR TITLE
sheared ellipse support

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -375,6 +375,28 @@ void Canvas::drawEllipse(int X, int Y, int width, int height)
 }
 
 
+void Canvas::drawEllipseSheared(int X, int Y, int width, int height, int shear)
+{
+  moveTo(X, Y);
+  Primitive p;
+  p.cmd = PrimitiveCmd::DrawEllipseSheared;
+  p.ellipseShearedParams.size = Size(width, height);
+  p.ellipseShearedParams.shear = shear;
+  m_displayController->addPrimitive(p);
+}
+
+
+void Canvas::fillEllipseSheared(int X, int Y, int width, int height, int shear)
+{
+  moveTo(X, Y);
+  Primitive p;
+  p.cmd = PrimitiveCmd::FillEllipseSheared;
+  p.ellipseShearedParams.size = Size(width, height);
+  p.ellipseShearedParams.shear = shear;
+  m_displayController->addPrimitive(p);
+}
+
+
 void Canvas::drawArc(int X, int Y, int X1, int Y1, int X2, int Y2)
 {
   moveTo(X, Y);

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -593,6 +593,29 @@ public:
   void fillEllipse(int X, int Y, int width, int height);
 
   /**
+   * @brief Draws the outline of a horizontally-sheared ellipse, using current pen color.
+   *
+   * The ellipse has an axis-aligned bounding ellipse of (width × height) but is
+   * horizontally sheared: rows offset by dy from the centre are shifted by
+   * (shear * dy / (height/2)) pixels horizontally. With shear=0 this is an
+   * axis-aligned ellipse.
+   *
+   * @param X Horizontal coordinate of the ellipse center.
+   * @param Y Vertical coordinate of the ellipse center.
+   * @param width Full width (2a) of the ellipse.
+   * @param height Full height (2b) of the ellipse.
+   * @param shear Horizontal shear: x-offset of the top of the ellipse from directly above centre.
+   */
+  void drawEllipseSheared(int X, int Y, int width, int height, int shear);
+
+  /**
+   * @brief Fills a horizontally-sheared ellipse, using current brush color.
+   *
+   * See drawEllipseSheared() for the shear semantics.
+   */
+  void fillEllipseSheared(int X, int Y, int width, int height, int shear);
+
+  /**
    * @brief Draws a glyph at specified position.
    *
    * A Glyph is a monochrome bitmap (1 bit per pixel) that can be painted using pen (foreground) and brush (background) colors.<br>

--- a/src/dispdrivers/vga16controller.cpp
+++ b/src/dispdrivers/vga16controller.cpp
@@ -395,6 +395,13 @@ void VGA16Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA16Controller::absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipseSheared(params, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA16Controller::drawArc(Rect const & rect, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga16controller.h
+++ b/src/dispdrivers/vga16controller.h
@@ -197,6 +197,7 @@ private:
   void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color);
   void absFillRowScan(FillRowParams const & params, Rect & updateRect);
   void absFloodFill(FillRowParams const & params, Rect & updateRect);
+  void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }

--- a/src/dispdrivers/vga2controller.cpp
+++ b/src/dispdrivers/vga2controller.cpp
@@ -376,6 +376,13 @@ void VGA2Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA2Controller::absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipseSheared(params, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA2Controller::drawArc(Rect const & rect, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga2controller.h
+++ b/src/dispdrivers/vga2controller.h
@@ -199,6 +199,7 @@ private:
   void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color);
   void absFillRowScan(FillRowParams const & params, Rect & updateRect);
   void absFloodFill(FillRowParams const & params, Rect & updateRect);
+  void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }

--- a/src/dispdrivers/vga4controller.cpp
+++ b/src/dispdrivers/vga4controller.cpp
@@ -406,6 +406,13 @@ void VGA4Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA4Controller::absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipseSheared(params, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA4Controller::drawArc(Rect const & rect, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga4controller.h
+++ b/src/dispdrivers/vga4controller.h
@@ -196,6 +196,7 @@ private:
   void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color);
   void absFillRowScan(FillRowParams const & params, Rect & updateRect);
   void absFloodFill(FillRowParams const & params, Rect & updateRect);
+  void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }

--- a/src/dispdrivers/vga64controller.cpp
+++ b/src/dispdrivers/vga64controller.cpp
@@ -310,6 +310,13 @@ void VGA64Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA64Controller::absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipseSheared(params, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA64Controller::drawArc(Rect const & rect, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga64controller.h
+++ b/src/dispdrivers/vga64controller.h
@@ -201,6 +201,7 @@ private:
   void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color);
   void absFillRowScan(FillRowParams const & params, Rect & updateRect);
   void absFloodFill(FillRowParams const & params, Rect & updateRect);
+  void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }

--- a/src/dispdrivers/vga8controller.cpp
+++ b/src/dispdrivers/vga8controller.cpp
@@ -375,6 +375,13 @@ void VGA8Controller::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGA8Controller::absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipseSheared(params, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void VGA8Controller::drawArc(Rect const & rect, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vga8controller.h
+++ b/src/dispdrivers/vga8controller.h
@@ -200,6 +200,7 @@ private:
   void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color);
   void absFillRowScan(FillRowParams const & params, Rect & updateRect);
   void absFloodFill(FillRowParams const & params, Rect & updateRect);
+  void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }

--- a/src/dispdrivers/vgacontroller.cpp
+++ b/src/dispdrivers/vgacontroller.cpp
@@ -382,6 +382,13 @@ void IRAM_ATTR VGAController::drawEllipse(Size const & size, Rect & updateRect)
 }
 
 
+void VGAController::absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto mode = paintState().paintOptions.mode;
+  genericDrawEllipseSheared(params, updateRect, getPixelLambda(mode), setPixelLambda(mode));
+}
+
+
 void IRAM_ATTR VGAController::drawArc(Rect const & rect, Rect & updateRect)
 {
   auto mode = paintState().paintOptions.mode;

--- a/src/dispdrivers/vgacontroller.h
+++ b/src/dispdrivers/vgacontroller.h
@@ -286,6 +286,7 @@ private:
   void absDrawLine(int X1, int Y1, int X2, int Y2, RGB888 color);
   void absFillRowScan(FillRowParams const & params, Rect & updateRect);
   void absFloodFill(FillRowParams const & params, Rect & updateRect);
+  void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   // abstract method of BitmappedDisplayController
   int getBitmapSavePixelSize() { return 1; }

--- a/src/displaycontroller.cpp
+++ b/src/displaycontroller.cpp
@@ -834,6 +834,12 @@ void IRAM_ATTR BitmappedDisplayController::execPrimitive(Primitive const & prim,
     case PrimitiveCmd::DrawEllipse:
       drawEllipse(prim.size, updateRect);
       break;
+    case PrimitiveCmd::FillEllipseSheared:
+      fillEllipseSheared(prim.ellipseShearedParams, updateRect);
+      break;
+    case PrimitiveCmd::DrawEllipseSheared:
+      drawEllipseSheared(prim.ellipseShearedParams, updateRect);
+      break;
     case PrimitiveCmd::DrawArc:
       drawArc(prim.rect, updateRect);
       break;
@@ -1296,6 +1302,120 @@ void IRAM_ATTR BitmappedDisplayController::fillEllipse(int centerX, int centerY,
   // one line horizontal ellipse case
   if (halfHeight == 0 && centerY >= clipY1 && centerY <= clipY2)
     fillRow(centerY, iclamp(centerX - halfWidth, clipX1, clipX2), iclamp(centerX - halfWidth + 2 * halfWidth + 1, clipX1, clipX2), color);
+}
+
+
+void IRAM_ATTR BitmappedDisplayController::drawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  absDrawEllipseSheared(params, updateRect);
+}
+
+
+// Horizontally-sheared ellipse fill (Acorn PLOT &C8 family).
+// Scanline approach: iterate dy from 0 to halfH, compute the two x boundaries
+// of the ellipse on the corresponding rows (upper at cy-dy with +shear_offset,
+// lower at cy+dy with -shear_offset), and fill each row via virtual fillRow
+// (which handles paint modes per the display driver).
+void IRAM_ATTR BitmappedDisplayController::fillEllipseSheared(EllipseShearedParams const & params, Rect & updateRect)
+{
+  auto & pState = paintState();
+  auto & clip = pState.absClippingRect;
+  const RGB888 color = getActualBrushColor();
+
+  const int cx = pState.position.X;
+  const int cy = pState.position.Y;
+  const int halfW = params.size.width / 2;
+  const int halfH = params.size.height / 2;
+  const int shear = params.shear;
+
+  const int shearMag = shear < 0 ? -shear : shear;
+  updateRect = updateRect.merge(Rect(cx - halfW - shearMag, cy - halfH, cx + halfW + shearMag, cy + halfH));
+  hideSprites(updateRect);
+
+  auto doFillRow = [&](int y, int xL, int xR) {
+    if (y < clip.Y1 || y > clip.Y2) return;
+    if (xR < xL) return;
+    int a = xL < clip.X1 ? (int)clip.X1 : xL;
+    int b = xR > clip.X2 ? (int)clip.X2 : xR;
+    if (a > b) return;
+    fillRow(y, a, b, color);
+  };
+
+  // Degenerate: zero-height ellipse is a single horizontal line.
+  if (halfH == 0) {
+    doFillRow(cy, cx - halfW, cx + halfW);
+    return;
+  }
+
+  const float invHalfH = 1.0f / halfH;
+  auto roundToInt = [](float f) -> int {
+    return (int)(f >= 0.0f ? f + 0.5f : f - 0.5f);
+  };
+
+  // Match the outline algorithm: plot the same Bresenham-style connection pixels
+  // between adjacent rows' edge points. Some land outside the row's natural fill
+  // extent and need explicit painting to match the outline silhouette. Others land
+  // inside — under Set mode those are merely redundant, but under Invert/XOR the
+  // second paint cancels the first, so we must skip them.
+  auto connectEdge = [&](int xA, int yA, int xB, int yB, bool isRightEdge) {
+    int dx = xB - xA;
+    int adx = dx < 0 ? -dx : dx;
+    if (adx <= 1) return;
+    int stepX = dx > 0 ? 1 : -1;
+    int midpoint = adx / 2;
+    int x = xA;
+    for (int i = 1; i < adx; i++) {
+      x += stepX;
+      bool isPrevSide = (i <= midpoint);
+      int y = isPrevSide ? yA : yB;
+      int edge = isPrevSide ? xA : xB;
+      // "Inside" = on the interior side of this edge (inside the row's natural fill).
+      bool inside = isRightEdge ? (x < edge) : (x > edge);
+      if (inside) continue;
+      // Plot single pixel via a 1-wide fillRow (respects paint modes).
+      doFillRow(y, x, x);
+    }
+  };
+
+  int prevUpperL = 0, prevUpperR = 0;
+  int prevLowerL = 0, prevLowerR = 0;
+  int prevUpperY = 0, prevLowerY = 0;
+  bool hasPrev = false;
+
+  for (int dy = 0; dy <= halfH; dy++) {
+    const float norm = dy * invHalfH;
+    const float discriminant = 1.0f - norm * norm;
+    const float halfWidthAtY_f = halfW * sqrtf(discriminant);
+    const float shearOffset_f  = shear * (float)dy * invHalfH;
+
+    const int upperY = cy - dy;
+    const int lowerY = cy + dy;
+    const int upperL = cx + roundToInt(shearOffset_f - halfWidthAtY_f);
+    const int upperR = cx + roundToInt(shearOffset_f + halfWidthAtY_f);
+    const int lowerL = cx + roundToInt(-shearOffset_f - halfWidthAtY_f);
+    const int lowerR = cx + roundToInt(-shearOffset_f + halfWidthAtY_f);
+
+    doFillRow(upperY, upperL, upperR);
+    if (dy != 0)
+      doFillRow(lowerY, lowerL, lowerR);
+
+    if (hasPrev) {
+      connectEdge(prevUpperL, prevUpperY, upperL, upperY, false);
+      connectEdge(prevUpperR, prevUpperY, upperR, upperY, true);
+      if (dy != 0) {
+        connectEdge(prevLowerL, prevLowerY, lowerL, lowerY, false);
+        connectEdge(prevLowerR, prevLowerY, lowerR, lowerY, true);
+      }
+    }
+
+    prevUpperL = upperL;
+    prevUpperR = upperR;
+    prevLowerL = lowerL;
+    prevLowerR = lowerR;
+    prevUpperY = upperY;
+    prevLowerY = lowerY;
+    hasPrev = true;
+  }
 }
 
 

--- a/src/displaycontroller.h
+++ b/src/displaycontroller.h
@@ -131,6 +131,15 @@ enum PrimitiveCmd : uint8_t {
   // params: size
   DrawEllipse,
 
+  // Fill a horizontally-sheared ellipse, current position is the center, using current brush color.
+  // Width/height specify full axes (2a, 2b); shear is horizontal offset of top from centre.
+  // params: ellipseShearedParams
+  FillEllipseSheared,
+
+  // Draw outline of a horizontally-sheared ellipse, current position is the center, using current pen color.
+  // params: ellipseShearedParams
+  DrawEllipseSheared,
+
   // Draw an arc of a circle, current position is the center, using current pen color
   // params: rect (providing a startPoint and endPoint)
   DrawArc,
@@ -720,6 +729,12 @@ struct FillRowParams {
 } __attribute__ ((packed));
 
 
+struct EllipseShearedParams {
+  Size    size;         // full width (2a) and full height (2b)
+  int16_t shear;        // horizontal shear: x-offset of the "top" point from the centre
+} __attribute__ ((packed));
+
+
 struct Primitive {
   PrimitiveCmd cmd;
   union {
@@ -740,6 +755,7 @@ struct Primitive {
     LinePattern            linePattern;
     LineOptions            lineOptions;
     FillRowParams          fillRowParams;
+    EllipseShearedParams   ellipseShearedParams;
     TaskHandle_t           notifyTask;
   } __attribute__ ((packed));
 
@@ -1071,6 +1087,8 @@ protected:
 
   virtual void drawEllipse(Size const & size, Rect & updateRect) = 0;
 
+  virtual void absDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect) = 0;
+
   virtual void drawArc(Rect const & rect, Rect & updateRect) = 0;
 
   virtual void fillSegment(Rect const & rect, Rect & updateRect) = 0;
@@ -1138,6 +1156,10 @@ protected:
   void fillRect(Rect const & rect, RGB888 const & color, Rect & updateRect);
 
   void fillEllipse(int centerX, int centerY, Size const & size, RGB888 const & color, Rect & updateRect);
+
+  void drawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
+
+  void fillEllipseSheared(EllipseShearedParams const & params, Rect & updateRect);
 
   void fillPath(Path const & path, RGB888 const & color, Rect & updateRect);
 
@@ -1423,6 +1445,132 @@ protected:
         dyt += d2yt;
         t += dyt;
       }
+    }
+  }
+
+
+  // Outline of a horizontally-sheared ellipse (Acorn PLOT &C0 family).
+  // Scanline-based: for each vertical offset dy from the centre, compute the two
+  // x boundaries of the ellipse on that row, with a horizontal shear proportional
+  // to dy. Adjacent rows' edge pixels are connected with a short diagonal segment
+  // (Bresenham-style: split between the two rows, with the transition in the
+  // middle of the horizontal run) to avoid gaps where the slope is steep.
+  template <typename TPreparePixel, typename TRawSetPixel>
+  void genericDrawEllipseSheared(EllipseShearedParams const & params, Rect & updateRect,
+                                 TPreparePixel preparePixel, TRawSetPixel rawSetPixel)
+  {
+    auto & pState = paintState();
+    auto & clip = pState.absClippingRect;
+    auto pattern = preparePixel(getActualPenColor());
+
+    const int cx = pState.position.X;
+    const int cy = pState.position.Y;
+    const int halfW = params.size.width / 2;
+    const int halfH = params.size.height / 2;
+    const int shear = params.shear;
+
+    // Conservative update rect covering the sheared bounding box.
+    const int xSpan = halfW + (shear < 0 ? -shear : shear);
+    updateRect = updateRect.merge(Rect(cx - xSpan, cy - halfH, cx + xSpan, cy + halfH));
+    hideSprites(updateRect);
+
+    // Degenerate: zero-height ellipse is a horizontal line at cy.
+    if (halfH == 0) {
+      if (cy < clip.Y1 || cy > clip.Y2) return;
+      int x1 = iclamp(cx - halfW, (int)clip.X1, (int)clip.X2);
+      int x2 = iclamp(cx + halfW, (int)clip.X1, (int)clip.X2);
+      for (int x = x1; x <= x2; x++)
+        rawSetPixel(x, cy, pattern);
+      return;
+    }
+
+    auto plotPixel = [&](int x, int y) {
+      if (x >= clip.X1 && x <= clip.X2 && y >= clip.Y1 && y <= clip.Y2)
+        rawSetPixel(x, y, pattern);
+    };
+
+    // Draw a short line from (xA, yA) to (xB, yB) where the Y distance is 0 or 1.
+    // Bresenham-style: for a flat slope, distribute intermediate pixels between
+    // yA and yB with the transition in the middle of the horizontal run.
+    // skipPrevSide: if true, omit pixels on the yA row — used at dy=1 for the
+    // lower connection so that centre-row pixels (which the upper connection
+    // already covers) aren't plotted a second time.
+    auto connectShort = [&](int xA, int yA, int xB, int yB, bool skipPrevSide) {
+      if (xA == xB && yA == yB) return;
+      int dx = xB - xA;
+      int adx = dx < 0 ? -dx : dx;
+      if (adx <= 1) return;
+      int stepX = dx > 0 ? 1 : -1;
+      int midpoint = adx / 2;
+      int x = xA;
+      for (int i = 1; i < adx; i++) {
+        x += stepX;
+        bool isPrevSide = (i <= midpoint);
+        if (skipPrevSide && isPrevSide) continue;
+        int y = isPrevSide ? yA : yB;
+        plotPixel(x, y);
+      }
+    };
+
+    const float invHalfH = 1.0f / halfH;
+
+    int prevUpperL = 0, prevUpperR = 0;
+    int prevLowerL = 0, prevLowerR = 0;
+    int prevUpperY = 0, prevLowerY = 0;
+    bool hasPrev = false;
+
+    auto roundToInt = [](float f) -> int {
+      return (int)(f >= 0.0f ? f + 0.5f : f - 0.5f);
+    };
+
+    for (int dy = 0; dy <= halfH; dy++) {
+      // Compute edge positions in float, round once. This avoids compounding
+      // rounding errors that happen if shearOffset and halfWidthAtY are rounded
+      // separately then added.
+      const float norm = dy * invHalfH;
+      const float discriminant = 1.0f - norm * norm;
+      const float halfWidthAtY_f = halfW * sqrtf(discriminant);
+      const float shearOffset_f  = shear * (float)dy * invHalfH;
+
+      const int upperY = cy - dy;
+      const int lowerY = cy + dy;
+      const int upperL = cx + roundToInt(shearOffset_f - halfWidthAtY_f);
+      const int upperR = cx + roundToInt(shearOffset_f + halfWidthAtY_f);
+      const int lowerL = cx + roundToInt(-shearOffset_f - halfWidthAtY_f);
+      const int lowerR = cx + roundToInt(-shearOffset_f + halfWidthAtY_f);
+
+      // Where upperL==upperR (e.g. topmost row where halfWidthAtY rounds to 0),
+      // only plot once — a double-plot would cancel under XOR/Invert, leaving a gap.
+      plotPixel(upperL, upperY);
+      if (upperR != upperL) plotPixel(upperR, upperY);
+      if (dy != 0) {
+        plotPixel(lowerL, lowerY);
+        if (lowerR != lowerL) plotPixel(lowerR, lowerY);
+      }
+
+      // Connect each edge to the previous row's corresponding edge with a short
+      // diagonal segment, filling any multi-pixel gaps smoothly rather than with
+      // horizontal flanges.
+      // At dy=1 the lower connection starts from the same (centre) row as the
+      // upper connection, so its prev-side pixels would overlap upper's —
+      // skip them for the lower connection so every pixel is plotted at most once.
+      if (hasPrev) {
+        const bool lowerOverlapsCentre = (prevLowerY == prevUpperY);
+        connectShort(prevUpperL, prevUpperY, upperL, upperY, false);
+        connectShort(prevUpperR, prevUpperY, upperR, upperY, false);
+        if (dy != 0) {
+          connectShort(prevLowerL, prevLowerY, lowerL, lowerY, lowerOverlapsCentre);
+          connectShort(prevLowerR, prevLowerY, lowerR, lowerY, lowerOverlapsCentre);
+        }
+      }
+
+      prevUpperL = upperL;
+      prevUpperR = upperR;
+      prevLowerL = lowerL;
+      prevLowerR = lowerR;
+      prevUpperY = upperY;
+      prevLowerY = lowerY;
+      hasPrev = true;
     }
   }
 


### PR DESCRIPTION
adds support for for “sheared” ellipses, in the same style that Acorn’s PLOT system provides

the canvas system supports primitives for both outline and filled ellipses.  these use an algorithm that is very similar to the one Acorn used, but with some minor subtle differences, which tend to make ellipses look a little better than they do on Acorn systems